### PR TITLE
Dataflow ZMQ paralelization for nonrandom sequences

### DIFF
--- a/tensorpack/dataflow/base.py
+++ b/tensorpack/dataflow/base.py
@@ -190,8 +190,8 @@ class DataFlowSequenceSlicer(ProxyDataFlowSequence):
         if None in [self.slicing_n, self.slicing_i]:
             return self.ds.size()
         else:
-            remainder_add = 1 if (self.ds.size() % self.slicing_n >= self.slicing_i) else 0
-            return int(self.ds.size() / self.slicing_n) + remainder_add
+            remainder_add = 1 if (self.ds.size() % self.slicing_n > self.slicing_i) else 0
+            return int(self.ds.size() // self.slicing_n) + remainder_add
 
 def is_sequence(ds):
     return isinstance(ds, DataFlowSequence) or (hasattr(ds, '__getitem__') and hasattr(ds, '__len__'))

--- a/tensorpack/dataflow/common.py
+++ b/tensorpack/dataflow/common.py
@@ -210,7 +210,10 @@ class BatchDataSequence(ProxyDataFlowSequence):
             data = self.ds[id*self.batch_size + i]
             holder.append(data)
 
-        return BatchData._aggregate_batch(holder, self.use_list)
+        if len(holder) <= 0:
+            return None
+
+        return BatchDataSequence._aggregate_batch(holder, self.use_list)
 
     @staticmethod
     def _aggregate_batch(data_holder, use_list=False):

--- a/tensorpack/dataflow/parallel.py
+++ b/tensorpack/dataflow/parallel.py
@@ -13,7 +13,7 @@ import os
 import zmq
 import atexit
 
-from .base import DataFlow, ProxyDataFlow, DataFlowTerminated, DataFlowReentrantGuard, DataFlowSequenceSlicer, IsSequence
+from .base import DataFlow, ProxyDataFlow, DataFlowTerminated, DataFlowReentrantGuard, DataFlowSequenceSlicer, is_sequence
 from ..utils.concurrency import (ensure_proc_terminate,
                                  mask_sigint, start_proc_mask_signal,
                                  enable_death_signal,
@@ -251,7 +251,7 @@ class PrefetchDataZMQ(_MultiProcessZMQDataFlow):
         def __init__(self, ds, conn_name, hwm, id, totalworkers):
             super(PrefetchDataZMQ._Worker, self).__init__()
 
-            if IsSequence(ds):
+            if is_sequence(ds):
                 self.ds = DataFlowSequenceSlicer(ds, id, totalworkers)
             else:
                 self.ds = ds

--- a/tensorpack/dataflow/parallel.py
+++ b/tensorpack/dataflow/parallel.py
@@ -13,7 +13,7 @@ import os
 import zmq
 import atexit
 
-from .base import DataFlow, ProxyDataFlow, DataFlowTerminated, DataFlowReentrantGuard
+from .base import DataFlow, ProxyDataFlow, DataFlowTerminated, DataFlowReentrantGuard, DataFlowSequenceSlicer, IsSequence
 from ..utils.concurrency import (ensure_proc_terminate,
                                  mask_sigint, start_proc_mask_signal,
                                  enable_death_signal,
@@ -248,11 +248,20 @@ class PrefetchDataZMQ(_MultiProcessZMQDataFlow):
     """
 
     class _Worker(mp.Process):
-        def __init__(self, ds, conn_name, hwm):
+        def __init__(self, ds, conn_name, hwm, id, totalworkers):
             super(PrefetchDataZMQ._Worker, self).__init__()
-            self.ds = ds
+
+            if IsSequence(ds):
+                self.ds = DataFlowSequenceSlicer(ds, id, totalworkers)
+            else:
+                self.ds = ds
+
             self.conn_name = conn_name
             self.hwm = hwm
+
+            # this worker is id-th from totalworkers
+            self.id = id
+            self.totalworkers = totalworkers
 
         def run(self):
             enable_death_signal()
@@ -288,7 +297,7 @@ class PrefetchDataZMQ(_MultiProcessZMQDataFlow):
         self._guard = DataFlowReentrantGuard()
         if nr_proc > 1:
             logger.info("[PrefetchDataZMQ] Will fork a dataflow more than one times. "
-                        "This assumes the datapoints are i.i.d.")
+                        "This assumes the datapoints are i.i.d. or come from slicable DataFlowSequence descendant")
         try:
             self._size = ds.size()
         except NotImplementedError:
@@ -314,8 +323,8 @@ class PrefetchDataZMQ(_MultiProcessZMQDataFlow):
         pipename = _get_pipe_name('dataflow')
         _bind_guard(self.socket, pipename)
 
-        self._procs = [PrefetchDataZMQ._Worker(self.ds, pipename, self._hwm)
-                       for _ in range(self.nr_proc)]
+        self._procs = [PrefetchDataZMQ._Worker(self.ds, pipename, self._hwm, i, self.nr_proc)
+                       for i in range(self.nr_proc)]
         self._start_processes()
 
 

--- a/tensorpack/dataflow/raw.py
+++ b/tensorpack/dataflow/raw.py
@@ -146,16 +146,14 @@ class SequenceFromList(RNGDataFlowSequence):
             shuffle (bool): shuffle data.
         """
         super(SequenceFromList, self).__init__()
-        self.orig_lst = lst
+        self.lst = copy.copy(lst)
         self.shuffle = shuffle
 
     def reset_state(self):
         RNGDataFlowSequence.reset_state(self)
 
         if self.shuffle:
-            self.lst = self.rng.shuffle(self.orig_lst)
-        else:
-            self.lst = self.orig_lst
+            self.rng.shuffle(self.lst)
 
     def size(self):
         return len(self.lst)

--- a/tensorpack/dataflow/raw.py
+++ b/tensorpack/dataflow/raw.py
@@ -6,10 +6,10 @@ import numpy as np
 import copy
 import six
 from six.moves import range
-from .base import DataFlow, RNGDataFlow
+from .base import DataFlow, RNGDataFlow, RNGDataFlowSequence
 from ..utils.develop import log_deprecated
 
-__all__ = ['FakeData', 'DataFromQueue', 'DataFromList', 'DataFromGenerator', 'DataFromIterable']
+__all__ = ['FakeData', 'DataFromQueue', 'DataFromList', 'DataFromGenerator', 'DataFromIterable', 'SequenceFromList']
 
 
 class FakeData(RNGDataFlow):
@@ -134,3 +134,31 @@ class DataFromIterable(DataFlow):
     def get_data(self):
         for dp in self._itr:
             yield dp
+
+
+class SequenceFromList(RNGDataFlowSequence):
+    """ Wrap a list of datapoints to a DataFlowSequence"""
+
+    def __init__(self, lst, shuffle=True):
+        """
+        Args:
+            lst (list): input list. Each element is a datapoint.
+            shuffle (bool): shuffle data.
+        """
+        super(SequenceFromList, self).__init__()
+        self.orig_lst = lst
+        self.shuffle = shuffle
+
+    def reset_state(self):
+        RNGDataFlowSequence.reset_state(self)
+
+        if self.shuffle:
+            self.lst = self.rng.shuffle(self.orig_lst)
+        else:
+            self.lst = self.orig_lst
+
+    def size(self):
+        return len(self.lst)
+
+    def __getitem__(self, id):
+        return self.lst[id]


### PR DESCRIPTION
Hello! 
We love dataflow and actually need to paralelize a specific generator, that needs to run over a list of items. That, of course, produced duplicates, so we came up with a solution.

Please, when You will have time, can You look at the changes? I tried to make the changes as minimal as they could be (the other way to add a slicing behavior would be to use reset_state for the generators, but that seemed to me like a lot of changes to existing code, so instead I tried to use new classes).

Thank You very much!