### PR TITLE
Free ZMQ multiprocess memory on demand

### DIFF
--- a/tensorpack/dataflow/base.py
+++ b/tensorpack/dataflow/base.py
@@ -107,3 +107,7 @@ class ProxyDataFlow(DataFlow):
 
     def get_data(self):
         return self.ds.get_data()
+
+    def __del__(self):
+        if hasattr(self.ds, "__del__"):
+            self.ds.__del__()

--- a/tensorpack/dataflow/parallel.py
+++ b/tensorpack/dataflow/parallel.py
@@ -123,6 +123,8 @@ class _MultiProcessZMQDataFlow(DataFlow):
                 x.terminate()
                 x.join(5)
             print("{} successfully cleaned-up.".format(type(self).__name__))
+            self._reset_done = False  # obviously if needed to be used again, needs to be reset again.
+            # Also prevents the print function to be called twice
         except Exception:
             pass
 

--- a/tensorpack/dataflow/parallel_map.py
+++ b/tensorpack/dataflow/parallel_map.py
@@ -294,6 +294,10 @@ class MultiProcessMapDataZMQ(_ParallelMapData, _MultiProcessZMQDataFlow):
                 for dp in self.get_data_non_strict():
                     yield dp
 
+    def __del__(self):
+        _MultiProcessZMQDataFlow.__del__(self)
+        _ParallelMapData.__del__(self)
+
 
 MultiProcessMapData = MultiProcessMapDataZMQ  # alias
 


### PR DESCRIPTION
In our application it can happen, that dataflows need to be created and deleted on demand (to free memory).
Obviously there the safe 'atexit' mechanism from parallel.py cannot help, because the main process lives forever.

Our dataflow is nested and has BatchData after MultiProcessMapData. 
After some experimenting with 'del the-final-dataflow-object' and even with context managers I was not able to free the memory whatsoever, because the __del__ method of MultiProcessMapData was not being called till the end of the main process.
The only working method was to call MultiProcessMapData __del__ directly. Only then the process manager showed that the forked python processes died.

So here I propose the ability to free the memory by propagating __del__ function from the last dataflow to the nested ones (saving the multiprocess just to call its del seems like a not elegant way of doing things).
Maybe it would be better to create some opposite function to 'reset_data', that could be called after the usage of dataflow, I would happily implement it of course :)


(Minimal working example to reproduce can be to create multiple dataflows with MultiProcessMapData and then trying to programatically free memory of some of them before the program termination).