### PR TITLE
Add LGTM configuration file to fix build failure.

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,6 @@
+extraction:
+  python:
+    prepare:
+      packages:
+        - libcap-dev
+


### PR DESCRIPTION
Add libcap-dev intallation in the LGTM build configuration
@ppwwyyxx this will make the LGTM build pass as discussed [here](https://github.com/ppwwyyxx/OpenPano/pull/73)
