### PR TITLE
update crowd label handeling

### DIFF
--- a/examples/FasterRCNN/config.py
+++ b/examples/FasterRCNN/config.py
@@ -139,7 +139,10 @@ _C.RPN.FG_RATIO = 0.5  # fg ratio among selected RPN anchors
 _C.RPN.BATCH_PER_IM = 256  # total (across FPN levels) number of anchors that are marked valid
 _C.RPN.MIN_SIZE = 0
 _C.RPN.PROPOSAL_NMS_THRESH = 0.7
-_C.RPN.CROWD_OVERLAP_THRESH = 0.7  # boxes overlapping crowd will be ignored.
+# Anchors which overlap with a crowd box (IOA larger than threshold) will be ignored.
+# Setting this to a value larger than 1.0 will disable the feature.
+# It is disabled by default because Detectron does not do this.
+_C.RPN.CROWD_OVERLAP_THRESH = 9.99
 _C.RPN.HEAD_DIM = 1024      # used in C4 only
 
 # RPN proposal selection -------------------------------

--- a/examples/FasterRCNN/data.py
+++ b/examples/FasterRCNN/data.py
@@ -160,7 +160,7 @@ def get_anchor_labels(anchors, gt_boxes, crowd_boxes):
         cand_inds = np.where(anchor_labels >= 0)[0]
         cand_anchors = anchors[cand_inds]
         ioas = np_ioa(crowd_boxes, cand_anchors)
-        overlap_with_crowd = cand_inds[np.transpose(ioas).max(axis=1) > cfg.RPN.CROWD_OVERLAP_THRES]
+        overlap_with_crowd = cand_inds[ioas.max(axis=0) > cfg.RPN.CROWD_OVERLAP_THRES]
         anchor_labels[overlap_with_crowd] = -1
 
     # Subsample fg labels: ignore some fg if fg is too many


### PR DESCRIPTION
The previous way to thresh anchor boxes based on iou is not a good metric.  For example, small anchors inside large crowd box would have small iou so not being ignored.

This PR update crowd label handling logic. Here, we use ioa instead of iou so that anchors that overlap with crowd boxes could be properly filtered out.