### PR TITLE
Prevent install python-prctl outside Linux when installing by wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ setup(
     ],
     tests_require=['flake8', 'scikit-image'],
     extras_require={
-        'all': ['pillow', 'scipy', 'h5py', 'lmdb>=0.92', 'matplotlib', 'scikit-learn'] +
-               ['python-prctl'] if platform.system() == 'Linux' else [],
+        'all': ['pillow', 'scipy', 'h5py', 'lmdb>=0.92', 'matplotlib', 'scikit-learn'],
+        'all: "Linux" in sys_platform': ['python-prctl'],
         'all: python_version < "3.0"': ['tornado'],
     },
 )


### PR DESCRIPTION
Closes #1148.

When `tensorpack` was installed by wheel the platform was already evaluated
and thus `python-prctl` was installed, even though it is Linux-specific.
Installing from source package or sources was OK.

Instead use a platform specifier that is evaluated while installing the wheel.