### PR TITLE
Don't add Keras phase callback if learning phase is fixed

### DIFF
--- a/tensorpack/contrib/keras.py
+++ b/tensorpack/contrib/keras.py
@@ -217,7 +217,7 @@ def setup_keras_trainer(
         input,
         get_cost,
         lambda: optimizer)
-    if len(keras.backend.learning_phase().consumers()) > 0:
+    if isinstance(keras.backend.learning_phase(), tf.Tensor) and len(keras.backend.learning_phase().consumers()) > 0:
         # check if learning_phase is used in this model
         trainer.register_callback(KerasPhaseCallback(True))
 


### PR DESCRIPTION
If the keras learning phase is set to a constant (e.g. via `K.set_learning_phase(0)`) before a model function is called, the learning phase is not a tensor and hence has no consumers. Don't need to register the phase callback in this case. 