### PR TITLE
fix "mnist-keras.py"

### DIFF
--- a/examples/keras/mnist-keras.py
+++ b/examples/keras/mnist-keras.py
@@ -42,7 +42,7 @@ def clear_tower0_name_scope():
 def get_keras_model():
     with clear_tower0_name_scope():
         M = keras.models.Sequential()
-        M.add(KL.Conv2D(32, 3, activation='relu', input_shape=[IMAGE_SIZE, IMAGE_SIZE, 1], padding='same'))
+        M.add(KL.Conv2D(32, 3, activation='relu', padding='same'))
         M.add(KL.BatchNormalization())
         M.add(KL.MaxPooling2D())
         M.add(KL.Conv2D(32, 3, activation='relu', padding='same'))


### PR DESCRIPTION
Otherwise I see the following error:
```
InvalidArgumentError (see above for traceback): You must feed a value for placeholder tensor 'conv2d_input' with dtype float and shape [?,28,28,1]
	 [[node conv2d_input (defined at examples/keras/mnist-keras.py:45) ]]
```
This way keras does not create an unnecessary Input and determines the shape from [`image`](https://github.com/tensorpack/tensorpack/blob/master/examples/keras/mnist-keras.py#L69)