### PR TITLE
Make augmentors return a `Transform` instance.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -376,6 +376,7 @@ _DEPRECATED_NAMES = set([
     'DistributedTrainerParameterServer',
     'InputDesc',
     'inputs_desc',
+    'Augmentor',
 
     # renamed items that should not appear in docs
     'DumpTensor',

--- a/examples/FasterRCNN/common.py
+++ b/examples/FasterRCNN/common.py
@@ -5,7 +5,7 @@ import numpy as np
 import cv2
 
 from tensorpack.dataflow import RNGDataFlow
-from tensorpack.dataflow.imgaug import transform
+from tensorpack.dataflow.imgaug import ImageAugmentor, ResizeTransform
 
 
 class DataFromListOfDict(RNGDataFlow):
@@ -26,7 +26,7 @@ class DataFromListOfDict(RNGDataFlow):
             yield dp
 
 
-class CustomResize(transform.TransformAugmentorBase):
+class CustomResize(ImageAugmentor):
     """
     Try resizing the shortest edge to a certain number
     while avoiding the longest edge to exceed max_size.
@@ -44,7 +44,7 @@ class CustomResize(transform.TransformAugmentorBase):
             short_edge_length = (short_edge_length, short_edge_length)
         self._init(locals())
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         h, w = img.shape[:2]
         size = self.rng.randint(
             self.short_edge_length[0], self.short_edge_length[1] + 1)
@@ -59,7 +59,7 @@ class CustomResize(transform.TransformAugmentorBase):
             neww = neww * scale
         neww = int(neww + 0.5)
         newh = int(newh + 0.5)
-        return transform.ResizeTransform(h, w, newh, neww, self.interp)
+        return ResizeTransform(h, w, newh, neww, self.interp)
 
 
 def box_to_point8(boxes):

--- a/examples/FasterRCNN/data.py
+++ b/examples/FasterRCNN/data.py
@@ -90,9 +90,10 @@ class TrainingDataPreprocessor:
             boxes[:, 1::2] *= height
 
         # augmentation:
-        im, params = self.aug.augment_return_params(im)
+        tfms = self.aug.get_transform(im)
+        im = tfms.apply_image(im)
         points = box_to_point8(boxes)
-        points = self.aug.augment_coords(points, params)
+        points = tfms.apply_coords(points)
         boxes = point8_to_box(points)
         if len(boxes):
             assert np.min(np_area(boxes)) > 0, "Some boxes have zero area!"
@@ -131,7 +132,7 @@ class TrainingDataPreprocessor:
             for polys in segmentation:
                 if not self.cfg.DATA.ABSOLUTE_COORD:
                     polys = [p * width_height for p in polys]
-                polys = [self.aug.augment_coords(p, params) for p in polys]
+                polys = [tfms.apply_coords(p) for p in polys]
                 masks.append(segmentation_to_mask(polys, im.shape[0], gt_mask_width))
 
             if len(masks):

--- a/examples/HED/hed.py
+++ b/examples/HED/hed.py
@@ -191,7 +191,7 @@ def get_data(name):
     ds = dataset.BSDS500(name, shuffle=True)
 
     class CropMultiple16(imgaug.ImageAugmentor):
-        def _get_augment_params(self, img):
+        def get_transform(self, img):
             newh = img.shape[0] // 16 * 16
             neww = img.shape[1] // 16 * 16
             assert newh > 0 and neww > 0
@@ -199,11 +199,7 @@ def get_data(name):
             h0 = 0 if diffh == 0 else self.rng.randint(diffh)
             diffw = img.shape[1] - neww
             w0 = 0 if diffw == 0 else self.rng.randint(diffw)
-            return (h0, w0, newh, neww)
-
-        def _augment(self, img, param):
-            h0, w0, newh, neww = param
-            return img[h0:h0 + newh, w0:w0 + neww]
+            return imgaug.CropTransform(h0, w0, newh, neww)
 
     if isTrain:
         shape_aug = [

--- a/tensorpack/dataflow/image.py
+++ b/tensorpack/dataflow/image.py
@@ -206,7 +206,7 @@ class AugmentImageComponents(MapData):
                 major_image = index[0]  # image to be used to get params. TODO better design?
                 im = copy_func(dp[major_image])
                 check_dtype(im)
-                tfms = self.augs.augment_get_transform(im)
+                tfms = self.augs.get_transform(im)
                 dp[major_image] = tfms.apply_image(im)
                 for idx in index[1:]:
                     check_dtype(dp[idx])

--- a/tensorpack/dataflow/image.py
+++ b/tensorpack/dataflow/image.py
@@ -161,10 +161,9 @@ class AugmentImageCoordinates(MapData):
             validate_coords(coords)
             if self._copy:
                 img, coords = copy_mod.deepcopy((img, coords))
-            img, tfms = self.augs.augment_return_tfm(img)
-            dp[self._img_index] = img
-            coords = tfms.apply_coords(coords)
-            dp[self._coords_index] = coords
+            tfms = self.augs.get_transform(img)
+            dp[self._img_index] = tfms.apply_image(img)
+            dp[self._coords_index] = tfms.apply_coords(coords)
             return dp
 
 
@@ -207,8 +206,8 @@ class AugmentImageComponents(MapData):
                 major_image = index[0]  # image to be used to get params. TODO better design?
                 im = copy_func(dp[major_image])
                 check_dtype(im)
-                im, tfms = self.augs.augment_return_tfm(im)
-                dp[major_image] = im
+                tfms = self.augs.augment_get_transform(im)
+                dp[major_image] = tfms.apply_image(im)
                 for idx in index[1:]:
                     check_dtype(dp[idx])
                     dp[idx] = tfms.apply_image(copy_func(dp[idx]))

--- a/tensorpack/dataflow/image.py
+++ b/tensorpack/dataflow/image.py
@@ -119,7 +119,7 @@ class AugmentImageComponent(MapDataComponent):
         with self._exception_handler.catch():
             if self._copy:
                 x = copy_mod.deepcopy(x)
-            return self.augs.apply(x)[0]
+            return self.augs.augment(x)
 
 
 class AugmentImageCoordinates(MapData):
@@ -161,7 +161,7 @@ class AugmentImageCoordinates(MapData):
             validate_coords(coords)
             if self._copy:
                 img, coords = copy_mod.deepcopy((img, coords))
-            img, tfms = self.augs.apply(img)
+            img, tfms = self.augs.augment_return_tfm(img)
             dp[self._img_index] = img
             coords = tfms.apply_coords(coords)
             dp[self._coords_index] = coords
@@ -207,7 +207,7 @@ class AugmentImageComponents(MapData):
                 major_image = index[0]  # image to be used to get params. TODO better design?
                 im = copy_func(dp[major_image])
                 check_dtype(im)
-                im, tfms = self.augs.apply(im)
+                im, tfms = self.augs.augment_return_tfm(im)
                 dp[major_image] = im
                 for idx in index[1:]:
                     check_dtype(dp[idx])

--- a/tensorpack/dataflow/image.py
+++ b/tensorpack/dataflow/image.py
@@ -119,7 +119,7 @@ class AugmentImageComponent(MapDataComponent):
         with self._exception_handler.catch():
             if self._copy:
                 x = copy_mod.deepcopy(x)
-            return self.augs.augment(x)
+            return self.augs.apply(x)[0]
 
 
 class AugmentImageCoordinates(MapData):
@@ -161,9 +161,9 @@ class AugmentImageCoordinates(MapData):
             validate_coords(coords)
             if self._copy:
                 img, coords = copy_mod.deepcopy((img, coords))
-            img, prms = self.augs.augment_return_params(img)
+            img, tfms = self.augs.apply(img)
             dp[self._img_index] = img
-            coords = self.augs.augment_coords(coords, prms)
+            coords = tfms.apply_coords(coords)
             dp[self._coords_index] = coords
             return dp
 
@@ -207,15 +207,15 @@ class AugmentImageComponents(MapData):
                 major_image = index[0]  # image to be used to get params. TODO better design?
                 im = copy_func(dp[major_image])
                 check_dtype(im)
-                im, prms = self.augs.augment_return_params(im)
+                im, tfms = self.augs.apply(im)
                 dp[major_image] = im
                 for idx in index[1:]:
                     check_dtype(dp[idx])
-                    dp[idx] = self.augs.augment_with_params(copy_func(dp[idx]), prms)
+                    dp[idx] = tfms.apply_image(copy_func(dp[idx]))
                 for idx in coords_index:
                     coords = copy_func(dp[idx])
                     validate_coords(coords)
-                    dp[idx] = self.augs.augment_coords(coords, prms)
+                    dp[idx] = tfms.apply_coords(coords)
                 return dp
 
         super(AugmentImageComponents, self).__init__(ds, func)

--- a/tensorpack/dataflow/imgaug/_test.py
+++ b/tensorpack/dataflow/imgaug/_test.py
@@ -10,13 +10,12 @@ from .crop import *
 from .deform import *
 from .imgproc import *
 from .noise import SaltPepperNoise
-from .noname import *
+from .misc import *
 
 anchors = [(0.2, 0.2), (0.7, 0.2), (0.8, 0.8), (0.5, 0.5), (0.2, 0.5)]
 augmentors = AugmentorList([
     Contrast((0.8, 1.2)),
     Flip(horiz=True),
-    GaussianDeform(anchors, (360, 480), 0.2, randrange=20),
     # RandomCropRandomShape(0.3),
     SaltPepperNoise()
 ])

--- a/tensorpack/dataflow/imgaug/_test.py
+++ b/tensorpack/dataflow/imgaug/_test.py
@@ -7,37 +7,142 @@ import numpy as np
 import cv2
 import unittest
 
-from . import AugmentorList
-from .crop import *
-from .deform import *
-from .imgproc import *
-from .noise import *
-from .misc import *
+from .base import ImageAugmentor, AugmentorList
+from .imgproc import Contrast
+from .noise import SaltPepperNoise
+from .misc import Flip, Resize
 
 
 def _rand_image(shape=(20, 20)):
     return np.random.rand(*shape).astype("float32")
 
 
+class LegacyBrightness(ImageAugmentor):
+    def __init__(self, delta, clip=True):
+        super(LegacyBrightness, self).__init__()
+        assert delta > 0
+        self._init(locals())
+
+    def _get_augment_params(self, _):
+        v = self._rand_range(-self.delta, self.delta)
+        return v
+
+    def _augment(self, img, v):
+        old_dtype = img.dtype
+        img = img.astype('float32')
+        img += v
+        if self.clip or old_dtype == np.uint8:
+            img = np.clip(img, 0, 255)
+        return img.astype(old_dtype)
+
+
+class LegacyFlip(ImageAugmentor):
+    def __init__(self, horiz=False, vert=False, prob=0.5):
+        super(LegacyFlip, self).__init__()
+        if horiz and vert:
+            raise ValueError("Cannot do both horiz and vert. Please use two Flip instead.")
+        elif horiz:
+            self.code = 1
+        elif vert:
+            self.code = 0
+        else:
+            raise ValueError("At least one of horiz or vert has to be True!")
+        self._init(locals())
+
+    def _get_augment_params(self, img):
+        h, w = img.shape[:2]
+        do = self._rand_range() < self.prob
+        return (do, h, w)
+
+    def _augment(self, img, param):
+        do, _, _ = param
+        if do:
+            ret = cv2.flip(img, self.code)
+            if img.ndim == 3 and ret.ndim == 2:
+                ret = ret[:, :, np.newaxis]
+        else:
+            ret = img
+        return ret
+
+    def _augment_coords(self, coords, param):
+        do, h, w = param
+        if do:
+            if self.code == 0:
+                coords[:, 1] = h - coords[:, 1]
+            elif self.code == 1:
+                coords[:, 0] = w - coords[:, 0]
+        return coords
+
+
 class ImgAugTest(unittest.TestCase):
-    def test_augmentors(self):
-        augmentors = AugmentorList([
+    def _get_augs(self):
+        return AugmentorList([
             Contrast((0.8, 1.2)),
             Flip(horiz=True),
             Resize((30, 30)),
             SaltPepperNoise()
         ])
 
+    def _get_augs_with_legacy(self):
+        return AugmentorList([
+            LegacyBrightness(0.5),
+            LegacyFlip(horiz=True),
+            Resize((30, 30)),
+            SaltPepperNoise()
+        ])
+
+    def test_augmentors(self):
+        augmentors = self._get_augs()
+
         img = _rand_image()
         orig = img.copy()
-        newimg, tfms = augmentors.apply(img)
+        newimg, tfms = augmentors.augment_return_tfm(img)
         print(augmentors, tfms)  # TODO better print
         newimg2 = tfms.apply_image(orig)
         self.assertTrue(np.allclose(newimg, newimg2))
         self.assertEqual(newimg2.shape[0], 30)
 
         coords = np.asarray([[0, 0], [10, 12]], dtype="float32")
-        new_coords = tfms.apply_coords(coords)
+        tfms.apply_coords(coords)
+
+    def test_legacy_usage(self):
+        augmentors = self._get_augs()
+
+        img = _rand_image()
+        orig = img.copy()
+        newimg, tfms = augmentors.augment_return_params(img)
+        newimg2 = augmentors.augment_with_params(orig, tfms)
+        self.assertTrue(np.allclose(newimg, newimg2))
+        self.assertEqual(newimg2.shape[0], 30)
+
+        coords = np.asarray([[0, 0], [10, 12]], dtype="float32")
+        augmentors.augment_coords(coords, tfms)
+
+    def test_legacy_augs_new_usage(self):
+        augmentors = self._get_augs_with_legacy()
+
+        img = _rand_image()
+        orig = img.copy()
+        newimg, tfms = augmentors.augment_return_tfm(img)
+        newimg2 = tfms.apply_image(orig)
+        self.assertTrue(np.allclose(newimg, newimg2))
+        self.assertEqual(newimg2.shape[0], 30)
+
+        coords = np.asarray([[0, 0], [10, 12]], dtype="float32")
+        tfms.apply_coords(coords)
+
+    def test_legacy_augs_legacy_usage(self):
+        augmentors = self._get_augs_with_legacy()
+
+        img = _rand_image()
+        orig = img.copy()
+        newimg, tfms = augmentors.augment_return_params(img)
+        newimg2 = augmentors.augment_with_params(orig, tfms)
+        self.assertTrue(np.allclose(newimg, newimg2))
+        self.assertEqual(newimg2.shape[0], 30)
+
+        coords = np.asarray([[0, 0], [10, 12]], dtype="float32")
+        augmentors.augment_coords(coords, tfms)
 
 
 if __name__ == '__main__':

--- a/tensorpack/dataflow/imgaug/_test.py
+++ b/tensorpack/dataflow/imgaug/_test.py
@@ -97,9 +97,14 @@ class ImgAugTest(unittest.TestCase):
         img = _rand_image()
         orig = img.copy()
         tfms = augmentors.get_transform(img)
-        print(augmentors, tfms)  # TODO better print
+
+        # test printing
+        print(augmentors)
+        print(tfms)
 
         newimg = tfms.apply_image(img)
+        print(tfms)  # lazy ones will instantiate after the first apply
+
         newimg2 = tfms.apply_image(orig)
         self.assertTrue(np.allclose(newimg, newimg2))
         self.assertEqual(newimg2.shape[0], 30)

--- a/tensorpack/dataflow/imgaug/_test.py
+++ b/tensorpack/dataflow/imgaug/_test.py
@@ -3,28 +3,57 @@
 
 
 import sys
+import numpy as np
 import cv2
+import unittest
 
 from . import AugmentorList
 from .crop import *
 from .deform import *
 from .imgproc import *
-from .noise import SaltPepperNoise
+from .noise import *
 from .misc import *
 
-anchors = [(0.2, 0.2), (0.7, 0.2), (0.8, 0.8), (0.5, 0.5), (0.2, 0.5)]
-augmentors = AugmentorList([
-    Contrast((0.8, 1.2)),
-    Flip(horiz=True),
-    # RandomCropRandomShape(0.3),
-    SaltPepperNoise()
-])
 
-img = cv2.imread(sys.argv[1])
-newimg, prms = augmentors._augment_return_params(img)
-cv2.imshow(" ", newimg.astype('uint8'))
-cv2.waitKey()
+def _rand_image(shape=(20, 20)):
+    return np.random.rand(*shape).astype("float32")
 
-newimg = augmentors._augment(img, prms)
-cv2.imshow(" ", newimg.astype('uint8'))
-cv2.waitKey()
+
+class ImgAugTest(unittest.TestCase):
+    def test_augmentors(self):
+        augmentors = AugmentorList([
+            Contrast((0.8, 1.2)),
+            Flip(horiz=True),
+            Resize((30, 30)),
+            SaltPepperNoise()
+        ])
+
+        img = _rand_image()
+        orig = img.copy()
+        newimg, tfms = augmentors.apply(img)
+        print(augmentors, tfms)  # TODO better print
+        newimg2 = tfms.apply_image(orig)
+        self.assertTrue(np.allclose(newimg, newimg2))
+        self.assertEqual(newimg2.shape[0], 30)
+
+        coords = np.asarray([[0, 0], [10, 12]], dtype="float32")
+        new_coords = tfms.apply_coords(coords)
+
+
+if __name__ == '__main__':
+    anchors = [(0.2, 0.2), (0.7, 0.2), (0.8, 0.8), (0.5, 0.5), (0.2, 0.5)]
+    augmentors = AugmentorList([
+        Contrast((0.8, 1.2)),
+        Flip(horiz=True),
+        # RandomCropRandomShape(0.3),
+        SaltPepperNoise()
+    ])
+
+    img = cv2.imread(sys.argv[1])
+    newimg, prms = augmentors._augment_return_params(img)
+    cv2.imshow(" ", newimg.astype('uint8'))
+    cv2.waitKey()
+
+    newimg = augmentors._augment(img, prms)
+    cv2.imshow(" ", newimg.astype('uint8'))
+    cv2.waitKey()

--- a/tensorpack/dataflow/imgaug/_test.py
+++ b/tensorpack/dataflow/imgaug/_test.py
@@ -96,8 +96,10 @@ class ImgAugTest(unittest.TestCase):
 
         img = _rand_image()
         orig = img.copy()
-        newimg, tfms = augmentors.augment_return_tfm(img)
+        tfms = augmentors.get_transform(img)
         print(augmentors, tfms)  # TODO better print
+
+        newimg = tfms.apply_image(img)
         newimg2 = tfms.apply_image(orig)
         self.assertTrue(np.allclose(newimg, newimg2))
         self.assertEqual(newimg2.shape[0], 30)
@@ -123,7 +125,8 @@ class ImgAugTest(unittest.TestCase):
 
         img = _rand_image()
         orig = img.copy()
-        newimg, tfms = augmentors.augment_return_tfm(img)
+        tfms = augmentors.get_transform(img)
+        newimg = tfms.apply_image(img)
         newimg2 = tfms.apply_image(orig)
         self.assertTrue(np.allclose(newimg, newimg2))
         self.assertEqual(newimg2.shape[0], 30)

--- a/tensorpack/dataflow/imgaug/base.py
+++ b/tensorpack/dataflow/imgaug/base.py
@@ -87,7 +87,8 @@ class ImageAugmentor(object):
             argstr = []
             for idx, f in enumerate(fields):
                 assert hasattr(self, f), \
-                    "Attribute {} not found! Default __repr__ only works if attributes match the constructor.".format(f)
+                    "Attribute {} in {} not found! Default __repr__ only works if " \
+                    "attributes match the constructor.".format(f, classname)
                 attr = getattr(self, f)
                 if idx >= index_field_has_default:
                     if attr is argspec.defaults[idx - index_field_has_default]:
@@ -98,7 +99,16 @@ class ImageAugmentor(object):
             log_once(e.args[0], 'warn')
             return super(Augmentor, self).__repr__()
 
-    def get_transform(self, d):
+    def get_transform(self, img):
+        """
+        Instantiate a :class:`Transform` object from the given image.
+
+        Args:
+            img (ndarray):
+
+        Returns:
+            Transform
+        """
         pass
 
     __str__ = __repr__

--- a/tensorpack/dataflow/imgaug/base.py
+++ b/tensorpack/dataflow/imgaug/base.py
@@ -288,10 +288,10 @@ class PhotometricAugmentor(ImageAugmentor):
     Subclass should implement `_get_params(img)` and `_impl(img, params)`.
     """
     def get_transform(self, img):
-        p = self._get_params(img)
+        p = self._get_augment_params(img)
         from .transform import PhotometricTransform
-        return PhotometricTransform(func=lambda img: self._impl(img, p),
+        return PhotometricTransform(func=lambda img: self._augment(img, p),
                                     name="from " + str(self))
 
-    def _get_params(self, _):
+    def _get_augment_params(self, _):
         return None

--- a/tensorpack/dataflow/imgaug/base.py
+++ b/tensorpack/dataflow/imgaug/base.py
@@ -214,16 +214,16 @@ class ImageAugmentor(object):
     # ###########################
     # Legacy interfaces:
     # ###########################
-    @deprecated("Please use `get_transform` instead!", "2020-06-06")
+    @deprecated("Please use `get_transform` instead!", "2020-06-06", max_num_warnings=3)
     def augment_return_params(self, d):
         t = self.get_transform(d)
         return t.apply_image(d), t
 
-    @deprecated("Please use `transform.apply_image` instead!", "2020-06-06")
+    @deprecated("Please use `transform.apply_image` instead!", "2020-06-06", max_num_warnings=3)
     def augment_with_params(self, d, param):
         return param.apply_image(d)
 
-    @deprecated("Please use `transform.apply_coords` instead!", "2020-06-06")
+    @deprecated("Please use `transform.apply_coords` instead!", "2020-06-06", max_num_warnings=3)
     def augment_coords(self, coords, param):
         return param.apply_coords(coords)
 

--- a/tensorpack/dataflow/imgaug/convert.py
+++ b/tensorpack/dataflow/imgaug/convert.py
@@ -4,13 +4,12 @@
 import numpy as np
 import cv2
 
-from .base import ImageAugmentor
-from .meta import MapImage
+from .base import PhotometricAugmentor
 
 __all__ = ['ColorSpace', 'Grayscale', 'ToUint8', 'ToFloat32']
 
 
-class ColorSpace(ImageAugmentor):
+class ColorSpace(PhotometricAugmentor):
     """ Convert into another color space.  """
 
     def __init__(self, mode, keepdims=True):
@@ -20,9 +19,10 @@ class ColorSpace(ImageAugmentor):
             keepdims (bool): keep the dimension of image unchanged if OpenCV
                 changes it.
         """
+        super(ColorSpace, self).__init__(func=self._func)
         self._init(locals())
 
-    def _augment(self, img, _):
+    def _impl(self, img, _):
         transf = cv2.cvtColor(img, self.mode)
         if self.keepdims:
             if len(transf.shape) is not len(img.shape):
@@ -43,13 +43,13 @@ class Grayscale(ColorSpace):
         super(Grayscale, self).__init__(mode, keepdims)
 
 
-class ToUint8(MapImage):
+class ToUint8(PhotometricAugmentor):
     """ Convert image to uint8. Useful to reduce communication overhead. """
-    def __init__(self):
-        super(ToUint8, self).__init__(lambda x: np.clip(x, 0, 255).astype(np.uint8), lambda x: x)
+    def _impl(self, img, _):
+        return np.clip(img, 0, 255).astype(np.uint8)
 
 
-class ToFloat32(MapImage):
+class ToFloat32(PhotometricAugmentor):
     """ Convert image to float32, may increase quality of the augmentor. """
-    def __init__(self):
-        super(ToFloat32, self).__init__(lambda x: x.astype(np.float32), lambda x: x)
+    def _impl(self, img, _):
+        return img.astype(np.float32)

--- a/tensorpack/dataflow/imgaug/convert.py
+++ b/tensorpack/dataflow/imgaug/convert.py
@@ -19,10 +19,10 @@ class ColorSpace(PhotometricAugmentor):
             keepdims (bool): keep the dimension of image unchanged if OpenCV
                 changes it.
         """
-        super(ColorSpace, self).__init__(func=self._func)
+        super(ColorSpace, self).__init__()
         self._init(locals())
 
-    def _impl(self, img, _):
+    def _augment(self, img, _):
         transf = cv2.cvtColor(img, self.mode)
         if self.keepdims:
             if len(transf.shape) is not len(img.shape):
@@ -45,11 +45,11 @@ class Grayscale(ColorSpace):
 
 class ToUint8(PhotometricAugmentor):
     """ Convert image to uint8. Useful to reduce communication overhead. """
-    def _impl(self, img, _):
+    def _augment(self, img, _):
         return np.clip(img, 0, 255).astype(np.uint8)
 
 
 class ToFloat32(PhotometricAugmentor):
     """ Convert image to float32, may increase quality of the augmentor. """
-    def _impl(self, img, _):
+    def _augment(self, img, _):
         return img.astype(np.float32)

--- a/tensorpack/dataflow/imgaug/crop.py
+++ b/tensorpack/dataflow/imgaug/crop.py
@@ -82,7 +82,7 @@ class RandomCropRandomShape(ImageAugmentor):
         w = self.rng.randint(self.wmin, wmax + 1)
         diffh = img.shape[0] - h
         diffw = img.shape[1] - w
-        assert diffh >= 0 and diffw >= 0
+        assert diffh >= 0 and diffw >= 0, str(diffh) + ", " + str(diffw)
         y0 = 0 if diffh == 0 else self.rng.randint(diffh)
         x0 = 0 if diffw == 0 else self.rng.randint(diffw)
         return CropTransform(y0, x0, h, w)

--- a/tensorpack/dataflow/imgaug/crop.py
+++ b/tensorpack/dataflow/imgaug/crop.py
@@ -6,14 +6,14 @@ import cv2
 
 from ...utils.argtools import shape2d
 from ...utils.develop import log_deprecated
-from .base import ImageAugmentor
-from .transform import CropTransform, TransformAugmentorBase
+from .base import ImageAugmentor, ImagePlaceholder
+from .transform import CropTransform, TransformList, ResizeTransform
 from .misc import ResizeShortestEdge
 
 __all__ = ['RandomCrop', 'CenterCrop', 'RandomCropRandomShape', 'GoogleNetRandomCropAndResize']
 
 
-class RandomCrop(TransformAugmentorBase):
+class RandomCrop(ImageAugmentor):
     """ Randomly crop the image into a smaller one """
 
     def __init__(self, crop_shape):
@@ -25,7 +25,7 @@ class RandomCrop(TransformAugmentorBase):
         super(RandomCrop, self).__init__()
         self._init(locals())
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         orig_shape = img.shape
         assert orig_shape[0] >= self.crop_shape[0] \
             and orig_shape[1] >= self.crop_shape[1], orig_shape
@@ -36,7 +36,7 @@ class RandomCrop(TransformAugmentorBase):
         return CropTransform(h0, w0, self.crop_shape[0], self.crop_shape[1])
 
 
-class CenterCrop(TransformAugmentorBase):
+class CenterCrop(ImageAugmentor):
     """ Crop the image at the center"""
 
     def __init__(self, crop_shape):
@@ -47,7 +47,7 @@ class CenterCrop(TransformAugmentorBase):
         crop_shape = shape2d(crop_shape)
         self._init(locals())
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         orig_shape = img.shape
         assert orig_shape[0] >= self.crop_shape[0] \
             and orig_shape[1] >= self.crop_shape[1], orig_shape
@@ -56,7 +56,7 @@ class CenterCrop(TransformAugmentorBase):
         return CropTransform(h0, w0, self.crop_shape[0], self.crop_shape[1])
 
 
-class RandomCropRandomShape(TransformAugmentorBase):
+class RandomCropRandomShape(ImageAugmentor):
     """ Random crop with a random shape"""
 
     def __init__(self, wmin, hmin,
@@ -74,7 +74,7 @@ class RandomCropRandomShape(TransformAugmentorBase):
             log_deprecated("RandomCropRandomShape(max_aspect_ratio)", "It is never implemented!", "2020-06-06")
         self._init(locals())
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         hmax = self.hmax or img.shape[0]
         wmax = self.wmax or img.shape[1]
         h = self.rng.randint(self.hmin, hmax + 1)
@@ -108,7 +108,7 @@ class GoogleNetRandomCropAndResize(ImageAugmentor):
         """
         self._init(locals())
 
-    def _augment(self, img, _):
+    def get_transform(self, img):
         h, w = img.shape[:2]
         area = h * w
         for _ in range(10):
@@ -121,12 +121,11 @@ class GoogleNetRandomCropAndResize(ImageAugmentor):
             if hh <= h and ww <= w:
                 x1 = 0 if w == ww else self.rng.randint(0, w - ww)
                 y1 = 0 if h == hh else self.rng.randint(0, h - hh)
-                out = img[y1:y1 + hh, x1:x1 + ww]
-                out = cv2.resize(out, (self.target_shape, self.target_shape), interpolation=self.interp)
-                return out
-        out = ResizeShortestEdge(self.target_shape, interp=self.interp).augment(img)
-        out = CenterCrop(self.target_shape).augment(out)
-        return out
-
-    def _augment_coords(self, coords, param):
-        raise NotImplementedError()
+                return TransformList([
+                    CropTransform(y1, x1, hh, ww),
+                    ResizeTransform(hh, ww, self.target_shape, self.target_shape, interp=self.interp)
+                ])
+        tfm1 = ResizeShortestEdge(self.target_shape, interp=self.interp).get_transform(img)
+        out_shape = (tfm1.new_h, tfm1.new_w)
+        tfm2 = CenterCrop(self.target_shape).get_transform(ImagePlaceholder(shape=out_shape))
+        return TransformList([tfm1, tfm2])

--- a/tensorpack/dataflow/imgaug/crop.py
+++ b/tensorpack/dataflow/imgaug/crop.py
@@ -70,6 +70,7 @@ class RandomCropRandomShape(ImageAugmentor):
             wmin, hmin, wmax, hmax: range to sample shape.
             max_aspect_ratio (float): this argument has no effect and is deprecated.
         """
+        super(RandomCropRandomShape, self).__init__()
         if max_aspect_ratio is not None:
             log_deprecated("RandomCropRandomShape(max_aspect_ratio)", "It is never implemented!", "2020-06-06")
         self._init(locals())
@@ -106,6 +107,7 @@ class GoogleNetRandomCropAndResize(ImageAugmentor):
             aspect_ratio_range (tuple(float)): Defaults to make aspect ratio in 3/4-4/3.
             target_shape (int): Defaults to 224, the standard ImageNet image shape.
         """
+        super(GoogleNetRandomCropAndResize, self).__init__()
         self._init(locals())
 
     def get_transform(self, img):

--- a/tensorpack/dataflow/imgaug/deform.py
+++ b/tensorpack/dataflow/imgaug/deform.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from ...utils import logger
 from .base import ImageAugmentor
+from .transform import TransformFactory
 
 __all__ = []
 
@@ -97,14 +98,11 @@ class GaussianDeform(ImageAugmentor):
             self.randrange = randrange
         self.sigma = sigma
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         v = self.rng.rand(self.K, 2).astype('float32') - 0.5
         v = v * 2 * self.randrange
-        return v
+        return TransformFactory(name=str(self), apply_image=lambda img: self._augment(img, v))
 
     def _augment(self, img, v):
         grid = self.grid + np.dot(self.gws, v)
         return np_sample(img, grid)
-
-    def _augment_coords(self, coords, param):
-        raise NotImplementedError()

--- a/tensorpack/dataflow/imgaug/external.py
+++ b/tensorpack/dataflow/imgaug/external.py
@@ -3,8 +3,32 @@
 import numpy as np
 
 from .base import ImageAugmentor
+from .transform import Transform
 
 __all__ = ['IAAugmentor', 'Albumentations']
+
+
+class IAATransform(Transform):
+    def __init__(self, aug, img_shape):
+        self._init(locals())
+
+    def apply_image(self, img):
+        return self.aug.augment_image(img)
+
+    def apply_coords(self, coords):
+        import imgaug as IA
+        points = [IA.Keypoint(x=x, y=y) for x, y in coords]
+        points = IA.KeypointsOnImage(points, shape=self.img_shape)
+        augmented = self.aug.augment_keypoints([points])[0].keypoints
+        return np.asarray([[p.x, p.y] for p in augmented])
+
+
+class AlbumentationsTransform(Transform):
+    def __init__(self, aug, param):
+        self._init(locals())
+
+    def apply_image(self, img):
+        return self.aug.apply(img, **self.param)
 
 
 class IAAugmentor(ImageAugmentor):
@@ -43,20 +67,8 @@ class IAAugmentor(ImageAugmentor):
         super(IAAugmentor, self).__init__()
         self._aug = augmentor
 
-    def _get_augment_params(self, img):
-        return (self._aug.to_deterministic(), img.shape)
-
-    def _augment(self, img, param):
-        aug, _ = param
-        return aug.augment_image(img)
-
-    def _augment_coords(self, coords, param):
-        import imgaug as IA
-        aug, shape = param
-        points = [IA.Keypoint(x=x, y=y) for x, y in coords]
-        points = IA.KeypointsOnImage(points, shape=shape)
-        augmented = aug.augment_keypoints([points])[0].keypoints
-        return np.asarray([[p.x, p.y] for p in augmented])
+    def get_transform(self, img):
+        return IAATransform(self._aug.to_deterministic(), img.shape)
 
 
 class Albumentations(ImageAugmentor):
@@ -81,11 +93,5 @@ class Albumentations(ImageAugmentor):
         super(Albumentations, self).__init__()
         self._aug = augmentor
 
-    def _get_augment_params(self, img):
-        return self._aug.get_params()
-
-    def _augment(self, img, param):
-        return self._aug.apply(img, **param)
-
-    def _augment_coords(self, coords, param):
-        raise NotImplementedError()
+    def get_transform(self, img):
+        return AlbumentationsTransform(self._aug, self._aug.get_params())

--- a/tensorpack/dataflow/imgaug/external.py
+++ b/tensorpack/dataflow/imgaug/external.py
@@ -23,14 +23,6 @@ class IAATransform(Transform):
         return np.asarray([[p.x, p.y] for p in augmented])
 
 
-class AlbumentationsTransform(Transform):
-    def __init__(self, aug, param):
-        self._init(locals())
-
-    def apply_image(self, img):
-        return self.aug.apply(img, **self.param)
-
-
 class IAAugmentor(ImageAugmentor):
     """
     Wrap an augmentor form the IAA library: https://github.com/aleju/imgaug.
@@ -69,6 +61,14 @@ class IAAugmentor(ImageAugmentor):
 
     def get_transform(self, img):
         return IAATransform(self._aug.to_deterministic(), img.shape)
+
+
+class AlbumentationsTransform(Transform):
+    def __init__(self, aug, param):
+        self._init(locals())
+
+    def apply_image(self, img):
+        return self.aug.apply(img, **self.param)
 
 
 class Albumentations(ImageAugmentor):

--- a/tensorpack/dataflow/imgaug/imgproc.py
+++ b/tensorpack/dataflow/imgaug/imgproc.py
@@ -264,6 +264,7 @@ class Lighting(PhotometricAugmentor):
             eigval: a vector of (3,). The eigenvalues of 3 channels.
             eigvec: a 3x3 matrix. Each column is one eigen vector.
         """
+        super(Lighting, self).__init__()
         eigval = np.asarray(eigval)
         eigvec = np.asarray(eigvec)
         assert eigval.shape == (3,)

--- a/tensorpack/dataflow/imgaug/imgproc.py
+++ b/tensorpack/dataflow/imgaug/imgproc.py
@@ -25,10 +25,10 @@ class Hue(PhotometricAugmentor):
         rgb = bool(rgb)
         self._init(locals())
 
-    def _get_params(self, _):
+    def _get_augment_params(self, _):
         return self._rand_range(*self.range)
 
-    def _impl(self, img, hue):
+    def _augment(self, img, hue):
         m = cv2.COLOR_BGR2HSV if not self.rgb else cv2.COLOR_RGB2HSV
         hsv = cv2.cvtColor(img, m)
         # https://docs.opencv.org/3.2.0/de/d25/imgproc_color_conversions.html#color_convert_rgb_hsv
@@ -57,10 +57,10 @@ class Brightness(PhotometricAugmentor):
         assert delta > 0
         self._init(locals())
 
-    def _get_params(self, _):
+    def _get_augment_params(self, _):
         return self._rand_range(-self.delta, self.delta)
 
-    def _impl(self, img, v):
+    def _augment(self, img, v):
         old_dtype = img.dtype
         img = img.astype('float32')
         img += v
@@ -82,10 +82,10 @@ class BrightnessScale(PhotometricAugmentor):
         super(BrightnessScale, self).__init__()
         self._init(locals())
 
-    def _get_params(self, _):
+    def _get_augment_params(self, _):
         return self._rand_range(*self.range)
 
-    def _impl(self, img, v):
+    def _augment(self, img, v):
         old_dtype = img.dtype
         img = img.astype('float32')
         img *= v
@@ -109,10 +109,10 @@ class Contrast(PhotometricAugmentor):
         super(Contrast, self).__init__()
         self._init(locals())
 
-    def _get_params(self, _):
+    def _get_augment_params(self, _):
         return self._rand_range(*self.factor_range)
 
-    def _impl(self, img, r):
+    def _augment(self, img, r):
         old_dtype = img.dtype
 
         if img.ndim == 3:
@@ -147,7 +147,7 @@ class MeanVarianceNormalize(PhotometricAugmentor):
         """
         self._init(locals())
 
-    def _impl(self, img, _):
+    def _augment(self, img, _):
         img = img.astype('float32')
         if self.all_channel:
             mean = np.mean(img)
@@ -171,13 +171,13 @@ class GaussianBlur(PhotometricAugmentor):
         super(GaussianBlur, self).__init__()
         self._init(locals())
 
-    def _get_params(self, _):
+    def _get_augment_params(self, _):
         sx, sy = self.rng.randint(self.max_size, size=(2,))
         sx = sx * 2 + 1
         sy = sy * 2 + 1
         return sx, sy
 
-    def _impl(self, img, s):
+    def _augment(self, img, s):
         return np.reshape(cv2.GaussianBlur(img, s, sigmaX=0, sigmaY=0,
                                            borderType=cv2.BORDER_REPLICATE), img.shape)
 
@@ -192,10 +192,10 @@ class Gamma(PhotometricAugmentor):
         super(Gamma, self).__init__()
         self._init(locals())
 
-    def _get_params(self, _):
+    def _get_augment_params(self, _):
         return self._rand_range(*self.range)
 
-    def _impl(self, img, gamma):
+    def _augment(self, img, gamma):
         old_dtype = img.dtype
         lut = ((np.arange(256, dtype='float32') / 255) ** (1. / (1. + gamma)) * 255).astype('uint8')
         img = np.clip(img, 0, 255).astype('uint8')
@@ -215,7 +215,7 @@ class Clip(PhotometricAugmentor):
         """
         self._init(locals())
 
-    def _impl(self, img, _):
+    def _augment(self, img, _):
         return np.clip(img, self.min, self.max)
 
 
@@ -236,10 +236,10 @@ class Saturation(PhotometricAugmentor):
         assert alpha < 1
         self._init(locals())
 
-    def _get_params(self, _):
+    def _get_augment_params(self, _):
         return 1 + self._rand_range(-self.alpha, self.alpha)
 
-    def _impl(self, img, v):
+    def _augment(self, img, v):
         old_dtype = img.dtype
         m = cv2.COLOR_RGB2GRAY if self.rgb else cv2.COLOR_BGR2GRAY
         grey = cv2.cvtColor(img, m)
@@ -271,11 +271,11 @@ class Lighting(PhotometricAugmentor):
         assert eigvec.shape == (3, 3)
         self._init(locals())
 
-    def _get_params(self, img):
+    def _get_augment_params(self, img):
         assert img.shape[2] == 3
         return (self.rng.randn(3) * self.std).astype("float32")
 
-    def _impl(self, img, v):
+    def _augment(self, img, v):
         old_dtype = img.dtype
         v = v * self.eigval
         v = v.reshape((3, 1))
@@ -301,7 +301,7 @@ class MinMaxNormalize(PhotometricAugmentor):
         """
         self._init(locals())
 
-    def _impl(self, img, _):
+    def _augment(self, img, _):
         img = img.astype('float32')
         if self.all_channel:
             minimum = np.min(img)

--- a/tensorpack/dataflow/imgaug/meta.py
+++ b/tensorpack/dataflow/imgaug/meta.py
@@ -3,6 +3,7 @@
 
 
 from .base import ImageAugmentor
+from .transform import NoOpTransform, TransformList, TransformFactory
 
 __all__ = ['RandomChooseAug', 'MapImage', 'Identity', 'RandomApplyAug',
            'RandomOrderAug']
@@ -10,8 +11,8 @@ __all__ = ['RandomChooseAug', 'MapImage', 'Identity', 'RandomApplyAug',
 
 class Identity(ImageAugmentor):
     """ A no-op augmentor """
-    def _augment(self, img, _):
-        return img
+    def get_transform(self, img):
+        return NoOpTransform()
 
 
 class RandomApplyAug(ImageAugmentor):
@@ -28,37 +29,16 @@ class RandomApplyAug(ImageAugmentor):
         self._init(locals())
         super(RandomApplyAug, self).__init__()
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         p = self.rng.rand()
         if p < self.prob:
-            prm = self.aug._get_augment_params(img)
-            return (True, prm)
+            return self.aug.get_transform(img)
         else:
-            return (False, None)
-
-    def _augment_return_params(self, img):
-        p = self.rng.rand()
-        if p < self.prob:
-            img, prms = self.aug._augment_return_params(img)
-            return img, (True, prms)
-        else:
-            return img, (False, None)
+            return NoOpTransform()
 
     def reset_state(self):
         super(RandomApplyAug, self).reset_state()
         self.aug.reset_state()
-
-    def _augment(self, img, prm):
-        if not prm[0]:
-            return img
-        else:
-            return self.aug._augment(img, prm[1])
-
-    def _augment_coords(self, coords, prm):
-        if not prm[0]:
-            return coords
-        else:
-            return self.aug._augment_coords(coords, prm[1])
 
 
 class RandomChooseAug(ImageAugmentor):
@@ -82,18 +62,9 @@ class RandomChooseAug(ImageAugmentor):
         for a in self.aug_lists:
             a.reset_state()
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         aug_idx = self.rng.choice(len(self.aug_lists), p=self.prob)
-        aug_prm = self.aug_lists[aug_idx]._get_augment_params(img)
-        return aug_idx, aug_prm
-
-    def _augment(self, img, prm):
-        idx, prm = prm
-        return self.aug_lists[idx]._augment(img, prm)
-
-    def _augment_coords(self, coords, prm):
-        idx, prm = prm
-        return self.aug_lists[idx]._augment_coords(coords, prm)
+        return self.aug_lists[aug_idx].get_transform(img)
 
 
 class RandomOrderAug(ImageAugmentor):
@@ -115,30 +86,18 @@ class RandomOrderAug(ImageAugmentor):
         for a in self.aug_lists:
             a.reset_state()
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         # Note: If augmentors change the shape of image, get_augment_param might not work
         # All augmentors should only rely on the shape of image
         idxs = self.rng.permutation(len(self.aug_lists))
-        prms = [self.aug_lists[k]._get_augment_params(img)
+        tfms = [self.aug_lists[k].get_transform(img)
                 for k in range(len(self.aug_lists))]
-        return idxs, prms
-
-    def _augment(self, img, prm):
-        idxs, prms = prm
-        for k in idxs:
-            img = self.aug_lists[k]._augment(img, prms[k])
-        return img
-
-    def _augment_coords(self, coords, prm):
-        idxs, prms = prm
-        for k in idxs:
-            img = self.aug_lists[k]._augment_coords(coords, prms[k])
-        return img
+        return TransformList([tfms[k] for k in idxs])
 
 
 class MapImage(ImageAugmentor):
     """
-    Map the image array by a function.
+    Map the image array by simple functions.
     """
 
     def __init__(self, func, coord_func=None):
@@ -152,10 +111,8 @@ class MapImage(ImageAugmentor):
         self.func = func
         self.coord_func = coord_func
 
-    def _augment(self, img, _):
-        return self.func(img)
-
-    def _augment_coords(self, coords, _):
-        if self.coord_func is None:
-            raise NotImplementedError
-        return self.coord_func(coords)
+    def get_transform(self, img):
+        if self.coord_func:
+            return TransformFactory(name="MapImage", apply_image=self.func, apply_coords=self.coord_func)
+        else:
+            return TransformFactory(name="MapImage", apply_image=self.func)

--- a/tensorpack/dataflow/imgaug/meta.py
+++ b/tensorpack/dataflow/imgaug/meta.py
@@ -106,7 +106,7 @@ class MapImage(ImageAugmentor):
         Args:
             func: a function which takes an image array and return an augmented one
             coord_func: optional. A function which takes coordinates and return augmented ones.
-                Coordinates have the same format as :func:`ImageAugmentor.augment_coords`.
+                Coordinates should be Nx2 array of (x, y)s.
         """
         super(MapImage, self).__init__()
         self.func = func

--- a/tensorpack/dataflow/imgaug/meta.py
+++ b/tensorpack/dataflow/imgaug/meta.py
@@ -23,8 +23,8 @@ class RandomApplyAug(ImageAugmentor):
     def __init__(self, aug, prob):
         """
         Args:
-            aug (ImageAugmentor): an augmentor
-            prob (float): the probability
+            aug (ImageAugmentor): an augmentor.
+            prob (float): the probability to apply the augmentor.
         """
         self._init(locals())
         super(RandomApplyAug, self).__init__()
@@ -87,8 +87,9 @@ class RandomOrderAug(ImageAugmentor):
             a.reset_state()
 
     def get_transform(self, img):
-        # Note: If augmentors change the shape of image, get_augment_param might not work
-        # All augmentors should only rely on the shape of image
+        # Note: this makes assumption that the augmentors do not make changes
+        # to the image that will affect how the transforms will be instantiated
+        # in the subsequent augmentors.
         idxs = self.rng.permutation(len(self.aug_lists))
         tfms = [self.aug_lists[k].get_transform(img)
                 for k in range(len(self.aug_lists))]

--- a/tensorpack/dataflow/imgaug/misc.py
+++ b/tensorpack/dataflow/imgaug/misc.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 # File: misc.py
 
-
-import numpy as np
 import cv2
 
 from ...utils import logger
 from ...utils.argtools import shape2d
 from .base import ImageAugmentor
-from .transform import ResizeTransform, TransformAugmentorBase
+from .transform import ResizeTransform, NoOpTransform, FlipTransform, TransposeTransform
 
 __all__ = ['Flip', 'Resize', 'RandomResize', 'ResizeShortestEdge', 'Transpose']
 
@@ -27,40 +25,20 @@ class Flip(ImageAugmentor):
         super(Flip, self).__init__()
         if horiz and vert:
             raise ValueError("Cannot do both horiz and vert. Please use two Flip instead.")
-        elif horiz:
-            self.code = 1
-        elif vert:
-            self.code = 0
-        else:
+        if not horiz and not vert:
             raise ValueError("At least one of horiz or vert has to be True!")
         self._init(locals())
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         h, w = img.shape[:2]
         do = self._rand_range() < self.prob
-        return (do, h, w)
-
-    def _augment(self, img, param):
-        do, _, _ = param
-        if do:
-            ret = cv2.flip(img, self.code)
-            if img.ndim == 3 and ret.ndim == 2:
-                ret = ret[:, :, np.newaxis]
+        if not do:
+            return NoOpTransform()
         else:
-            ret = img
-        return ret
-
-    def _augment_coords(self, coords, param):
-        do, h, w = param
-        if do:
-            if self.code == 0:
-                coords[:, 1] = h - coords[:, 1]
-            elif self.code == 1:
-                coords[:, 0] = w - coords[:, 0]
-        return coords
+            return FlipTransform(h, w, self.horiz)
 
 
-class Resize(TransformAugmentorBase):
+class Resize(ImageAugmentor):
     """ Resize image to a target size"""
 
     def __init__(self, shape, interp=cv2.INTER_LINEAR):
@@ -72,13 +50,13 @@ class Resize(TransformAugmentorBase):
         shape = tuple(shape2d(shape))
         self._init(locals())
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         return ResizeTransform(
             img.shape[0], img.shape[1],
             self.shape[0], self.shape[1], self.interp)
 
 
-class ResizeShortestEdge(TransformAugmentorBase):
+class ResizeShortestEdge(ImageAugmentor):
     """
     Resize the shortest edge to a certain number while
     keeping the aspect ratio.
@@ -92,18 +70,17 @@ class ResizeShortestEdge(TransformAugmentorBase):
         size = int(size)
         self._init(locals())
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         h, w = img.shape[:2]
         scale = self.size * 1.0 / min(h, w)
         if h < w:
             newh, neww = self.size, int(scale * w + 0.5)
         else:
             newh, neww = int(scale * h + 0.5), self.size
-        return ResizeTransform(
-            h, w, newh, neww, self.interp)
+        return ResizeTransform(h, w, newh, neww, self.interp)
 
 
-class RandomResize(TransformAugmentorBase):
+class RandomResize(ImageAugmentor):
     """ Randomly rescale width and height of the image."""
 
     def __init__(self, xrange, yrange=None, minimum=(0, 0), aspect_ratio_thres=0.15,
@@ -137,7 +114,7 @@ class RandomResize(TransformAugmentorBase):
                 if yrange is not None:
                     logger.warn("aspect_ratio_thres==0, yrange is not used!")
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         cnt = 0
         h, w = img.shape[:2]
 
@@ -188,18 +165,8 @@ class Transpose(ImageAugmentor):
         self.prob = prob
         self._init()
 
-    def _get_augment_params(self, img):
-        return self._rand_range() < self.prob
-
-    def _augment(self, img, do):
-        ret = img
-        if do:
-            ret = cv2.transpose(img)
-            if img.ndim == 3 and ret.ndim == 2:
-                ret = ret[:, :, np.newaxis]
-        return ret
-
-    def _augment_coords(self, coords, do):
-        if do:
-            coords = coords[:, ::-1]
-        return coords
+    def get_transform(self, _):
+        if self._rand_range() < self.prob:
+            return TransposeTransform()
+        else:
+            return NoOpTransform()

--- a/tensorpack/dataflow/imgaug/misc.py
+++ b/tensorpack/dataflow/imgaug/misc.py
@@ -165,7 +165,7 @@ class Transpose(ImageAugmentor):
         self.prob = prob
 
     def get_transform(self, _):
-        if self._rand_range() < self.prob:
+        if self.rng.rand() < self.prob:
             return TransposeTransform()
         else:
             return NoOpTransform()

--- a/tensorpack/dataflow/imgaug/misc.py
+++ b/tensorpack/dataflow/imgaug/misc.py
@@ -163,7 +163,6 @@ class Transpose(ImageAugmentor):
         """
         super(Transpose, self).__init__()
         self.prob = prob
-        self._init()
 
     def get_transform(self, _):
         if self._rand_range() < self.prob:

--- a/tensorpack/dataflow/imgaug/noise.py
+++ b/tensorpack/dataflow/imgaug/noise.py
@@ -5,12 +5,12 @@
 import numpy as np
 import cv2
 
-from .base import ImageAugmentor
+from .base import PhotometricAugmentor
 
 __all__ = ['JpegNoise', 'GaussianNoise', 'SaltPepperNoise']
 
 
-class JpegNoise(ImageAugmentor):
+class JpegNoise(PhotometricAugmentor):
     """ Random JPEG noise. """
 
     def __init__(self, quality_range=(40, 100)):
@@ -21,15 +21,15 @@ class JpegNoise(ImageAugmentor):
         super(JpegNoise, self).__init__()
         self._init(locals())
 
-    def _get_augment_params(self, img):
+    def _get_params(self, img):
         return self.rng.randint(*self.quality_range)
 
-    def _augment(self, img, q):
+    def _impl(self, img, q):
         enc = cv2.imencode('.jpg', img, [cv2.IMWRITE_JPEG_QUALITY, q])[1]
         return cv2.imdecode(enc, 1).astype(img.dtype)
 
 
-class GaussianNoise(ImageAugmentor):
+class GaussianNoise(PhotometricAugmentor):
     """
     Add random Gaussian noise N(0, sigma^2) of the same shape to img.
     """
@@ -42,10 +42,10 @@ class GaussianNoise(ImageAugmentor):
         super(GaussianNoise, self).__init__()
         self._init(locals())
 
-    def _get_augment_params(self, img):
+    def _get_params(self, img):
         return self.rng.randn(*img.shape)
 
-    def _augment(self, img, noise):
+    def _impl(self, img, noise):
         old_dtype = img.dtype
         ret = img + noise * self.sigma
         if self.clip or old_dtype == np.uint8:
@@ -53,7 +53,7 @@ class GaussianNoise(ImageAugmentor):
         return ret.astype(old_dtype)
 
 
-class SaltPepperNoise(ImageAugmentor):
+class SaltPepperNoise(PhotometricAugmentor):
     """ Salt and pepper noise.
         Randomly set some elements in image to 0 or 255, regardless of its channels.
     """
@@ -67,10 +67,10 @@ class SaltPepperNoise(ImageAugmentor):
         super(SaltPepperNoise, self).__init__()
         self._init(locals())
 
-    def _get_augment_params(self, img):
+    def _get_params(self, img):
         return self.rng.uniform(low=0, high=1, size=img.shape)
 
-    def _augment(self, img, param):
+    def _impl(self, img, param):
         img[param > (1 - self.white_prob)] = 255
         img[param < self.black_prob] = 0
         return img

--- a/tensorpack/dataflow/imgaug/noise.py
+++ b/tensorpack/dataflow/imgaug/noise.py
@@ -21,10 +21,10 @@ class JpegNoise(PhotometricAugmentor):
         super(JpegNoise, self).__init__()
         self._init(locals())
 
-    def _get_params(self, img):
+    def _get_augment_params(self, img):
         return self.rng.randint(*self.quality_range)
 
-    def _impl(self, img, q):
+    def _augment(self, img, q):
         enc = cv2.imencode('.jpg', img, [cv2.IMWRITE_JPEG_QUALITY, q])[1]
         return cv2.imdecode(enc, 1).astype(img.dtype)
 
@@ -42,10 +42,10 @@ class GaussianNoise(PhotometricAugmentor):
         super(GaussianNoise, self).__init__()
         self._init(locals())
 
-    def _get_params(self, img):
+    def _get_augment_params(self, img):
         return self.rng.randn(*img.shape)
 
-    def _impl(self, img, noise):
+    def _augment(self, img, noise):
         old_dtype = img.dtype
         ret = img + noise * self.sigma
         if self.clip or old_dtype == np.uint8:
@@ -67,10 +67,10 @@ class SaltPepperNoise(PhotometricAugmentor):
         super(SaltPepperNoise, self).__init__()
         self._init(locals())
 
-    def _get_params(self, img):
+    def _get_augment_params(self, img):
         return self.rng.uniform(low=0, high=1, size=img.shape)
 
-    def _impl(self, img, param):
+    def _augment(self, img, param):
         img[param > (1 - self.white_prob)] = 255
         img[param < self.black_prob] = 0
         return img

--- a/tensorpack/dataflow/imgaug/paste.py
+++ b/tensorpack/dataflow/imgaug/paste.py
@@ -6,6 +6,7 @@ import numpy as np
 from abc import abstractmethod
 
 from .base import ImageAugmentor
+from .transform import TransformFactory
 
 __all__ = ['CenterPaste', 'BackgroundFiller', 'ConstantBackgroundFiller',
            'RandomPaste']
@@ -87,15 +88,16 @@ class RandomPaste(CenterPaste):
     Randomly paste the image onto a background canvas.
     """
 
-    def _get_augment_params(self, img):
+    def get_transform(self, img):
         img_shape = img.shape[:2]
         assert self.background_shape[0] > img_shape[0] and self.background_shape[1] > img_shape[1]
 
         y0 = self._rand_range(self.background_shape[0] - img_shape[0])
         x0 = self._rand_range(self.background_shape[1] - img_shape[1])
-        return int(x0), int(y0)
+        l = int(x0), int(y0)
+        return TransformFactory(name=str(self), apply_image=lambda img: self._impl(img, l))
 
-    def _augment(self, img, loc):
+    def _impl(self, img, loc):
         x0, y0 = loc
         img_shape = img.shape[:2]
         background = self.background_filler.fill(

--- a/tensorpack/dataflow/imgaug/paste.py
+++ b/tensorpack/dataflow/imgaug/paste.py
@@ -52,6 +52,10 @@ class ConstantBackgroundFiller(BackgroundFiller):
         return np.zeros(return_shape, dtype=img.dtype) + self.value
 
 
+# NOTE:
+# apply_coords should be implemeted in paste transform, but not yet done
+
+
 class CenterPaste(ImageAugmentor):
     """
     Paste the image onto the center of a background canvas.
@@ -68,7 +72,10 @@ class CenterPaste(ImageAugmentor):
 
         self._init(locals())
 
-    def _augment(self, img, _):
+    def get_transform(self, _):
+        return TransformFactory(name=str(self), apply_image=lambda img: self._impl(img))
+
+    def _impl(self, img):
         img_shape = img.shape[:2]
         assert self.background_shape[0] >= img_shape[0] and self.background_shape[1] >= img_shape[1]
 
@@ -78,9 +85,6 @@ class CenterPaste(ImageAugmentor):
         x0 = int((self.background_shape[1] - img_shape[1]) * 0.5)
         background[y0:y0 + img_shape[0], x0:x0 + img_shape[1]] = img
         return background
-
-    def _augment_coords(self, coords, param):
-        raise NotImplementedError()
 
 
 class RandomPaste(CenterPaste):

--- a/tensorpack/dataflow/imgaug/transform.py
+++ b/tensorpack/dataflow/imgaug/transform.py
@@ -8,6 +8,13 @@ import cv2
 
 from ...utils.argtools import log_once
 
+from .base import ImageAugmentor
+
+TransformAugmentorBase = ImageAugmentor
+"""
+Legacy alias. Please don't use TransformAugmentorBase.
+"""
+
 __all__ = []
 
 

--- a/tensorpack/dataflow/imgaug/transform.py
+++ b/tensorpack/dataflow/imgaug/transform.py
@@ -15,7 +15,7 @@ Legacy alias. Please don't use.
 # This legacy augmentor requires us to import base from here, causing circular dependency.
 # Should remove this in the future.
 
-__all__ = ["Transform"]
+__all__ = ["Transform", "ResizeTransform", "CropTransform", "FlipTransform", "TransformList", "TransformFactory"]
 
 
 # class WrappedImgFunc(object):
@@ -101,7 +101,16 @@ class Transform(BaseTransform):
 
 
 class ResizeTransform(Transform):
+    """
+    Resize the image.
+    """
     def __init__(self, h, w, new_h, new_w, interp):
+        """
+        Args:
+            h, w (int):
+            new_h, new_w (int):
+            interp (int): cv2 interpolation method
+        """
         super(ResizeTransform, self).__init__()
         self._init(locals())
 
@@ -121,6 +130,9 @@ class ResizeTransform(Transform):
 
 
 class CropTransform(Transform):
+    """
+    Crop a subimage from an image.
+    """
     def __init__(self, y0, x0, h, w):
         super(CropTransform, self).__init__()
         self._init(locals())
@@ -231,6 +243,9 @@ class PhotometricTransform(Transform):
 
 
 class TransformFactory(Transform):
+    """
+    Create a :class:`Transform` from user-provided functions.
+    """
     def __init__(self, name=None, **kwargs):
         """
         Args:
@@ -257,7 +272,14 @@ they do not perform actual transformation, but delegate to another Transform.
 
 
 class TransformList(BaseTransform):
+    """
+    Apply a list of transforms sequentially.
+    """
     def __init__(self, tfms):
+        """
+        Args:
+            tfms (list[Transform]):
+        """
         for t in tfms:
             assert isinstance(t, BaseTransform), t
         self.tfms = tfms

--- a/tensorpack/dataflow/imgaug/transform.py
+++ b/tensorpack/dataflow/imgaug/transform.py
@@ -15,7 +15,7 @@ Legacy alias. Please don't use.
 # This legacy augmentor requires us to import base from here, causing circular dependency.
 # Should remove this in the future.
 
-__all__ = []
+__all__ = ["Transform"]
 
 
 # class WrappedImgFunc(object):
@@ -62,18 +62,21 @@ class Transform(BaseTransform):
     A deterministic image transformation, used to implement
     the (probably random) augmentors.
 
-    This way the deterministic part
-    (the actual transformation which may be common between augmentors)
-    can be separated from the random part
-    (the random policy which is different between augmentors).
-
-    The implementation of each method may choose to modify its input data
-    in-place for efficient transformation.
-
     This class is also the place to provide a default implementation to any
     :meth:`apply_xxx` method.
     The current default is to raise NotImplementedError in any such methods.
+
+    All subclasses should implement `apply_image`.
+    The image should be of type uint8 in range [0, 255], or
+    floating point images in range [0, 1] or [0, 255]
+
+    Some subclasses may implement `apply_coords`, when applicable.
+    It should take and return a numpy array of Nx2, where each row is the (x, y) coordinate.
+
+    The implementation of each method may choose to modify its input data
+    in-place for efficient transformation.
     """
+
     def __init__(self):
         # provide an empty __init__, so that __repr__ will work nicely
         pass

--- a/tensorpack/dataflow/imgaug/transform.py
+++ b/tensorpack/dataflow/imgaug/transform.py
@@ -224,6 +224,8 @@ class PhotometricTransform(Transform):
     def __repr__(self):
         return "imgaug.PhotometricTransform({})".format(self._name if self._name else "")
 
+    __str__ = __repr__
+
 
 class TransformFactory(Transform):
     def __init__(self, name=None, **kwargs):
@@ -241,6 +243,8 @@ class TransformFactory(Transform):
 
     def __str__(self):
         return "imgaug.TransformFactory({})".format(self._name if self._name else "")
+
+    __repr__ = __str__
 
 
 """

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -7,7 +7,7 @@ cd $DIR
 export TF_CPP_MIN_LOG_LEVEL=2
 export TF_CPP_MIN_VLOG_LEVEL=2
 # test import (#471)
-python -c 'from tensorpack.dataflow.imgaug import transform'
+python -c 'from tensorpack.dataflow import imgaug'
 # Check that these private names can be imported because tensorpack is using them
 python -c "from tensorflow.python.client.session import _FetchHandler"
 python -c "from tensorflow.python.training.monitored_session import _HookedSession"
@@ -16,6 +16,7 @@ python -c "import tensorflow as tf; tf.Operation._add_control_input"
 # run tests
 python -m tensorpack.callbacks.param_test
 python -m tensorpack.tfutils.unit_tests
+python -m unittest tensorpack.dataflow.imgaug._test
 TENSORPACK_SERIALIZE=pyarrow python test_serializer.py
 TENSORPACK_SERIALIZE=msgpack python test_serializer.py
 


### PR DESCRIPTION
This deprecates the old interface of "Augmentor".
The `.augment` interface stays unchanged. The ones involving "parameters" (which I mainly learned from an ancient training system at Megvii) are changed.

Old interface:
```
im, params = aug.augment_return_params(im)
im2 = aug.augment_with_params(im2, params)
coords = aug.augment_coords(coords, params)
```

New interface:
```
tfm = aug.get_transform(im)  # a deterministic transform
im = tfm.apply_image(im)
im2 = tfm.apply_image(im2)
coords = tfm.apply_coords(coords)
```


Issues with the old one:
1. It returns an opaque object "params" and expect users pass it back. This is not a good design
2. Verbose and complicated interface

The new one replaces "params" by well-defined `Transform` instances, with their own methods to perform deterministic mapping. As a result:
1. many augmentors have simplified logic
2. some composite augmentors (e.g., `GoogleNetRandomCropAndResize`) automatically obtain coordinate mapping 
3. more use cases (e.g., create `Transform` manually, support more data structures) can be enabled easier.

Backward compatibility should be kept, even for custom augmentors (there are a few tests for this).