### PR TITLE
fix trainers.py error with latest version of horovod (0.17.0.post1)

### DIFF
--- a/tensorpack/train/trainers.py
+++ b/tensorpack/train/trainers.py
@@ -383,7 +383,7 @@ class HorovodTrainer(SingleCostTrainer):
         # lazy import
         import horovod.tensorflow as hvd
         import horovod
-        hvd_version = tuple(map(int, horovod.__version__.split('.')))
+        hvd_version = tuple(map(int, horovod.__version__.split('.')[:3]))
         self.hvd = hvd
 
         hvd.init()


### PR DESCRIPTION
Latest version of horovod ends with "post1", not an integer and broke trainers.py
