### PR TITLE
Save checkpoints and event files on Google Cloud Storage

### DIFF
--- a/tensorpack/callbacks/monitor.py
+++ b/tensorpack/callbacks/monitor.py
@@ -239,7 +239,7 @@ class TFEventWriter(MonitorBase):
         if logdir is None:
             logdir = logger.get_logger_dir()
         assert tf.gfile.IsDirectory(logdir), logdir
-        self._logdir = os.path.normpath(logdir)
+        self._logdir = logdir
         self._max_queue = max_queue
         self._flush_secs = flush_secs
         self._split_files = split_files

--- a/tensorpack/callbacks/monitor.py
+++ b/tensorpack/callbacks/monitor.py
@@ -17,7 +17,7 @@ import threading
 from ..compat import tfv1 as tf
 from ..libinfo import __git_version__
 from ..tfutils.summary import create_image_summary, create_scalar_summary
-from ..utils import logger
+from ..utils import fs, logger
 from ..utils.develop import HIDE_DOC
 from .base import Callback
 
@@ -239,7 +239,7 @@ class TFEventWriter(MonitorBase):
         if logdir is None:
             logdir = logger.get_logger_dir()
         assert tf.gfile.IsDirectory(logdir), logdir
-        self._logdir = logdir
+        self._logdir = fs.normpath(logdir)
         self._max_queue = max_queue
         self._flush_secs = flush_secs
         self._split_files = split_files

--- a/tensorpack/callbacks/saver.py
+++ b/tensorpack/callbacks/saver.py
@@ -45,7 +45,7 @@ class ModelSaver(Callback):
         # If None, allow it to be init, but fail later if used
         # For example, if chief_only=True, it can still be safely initialized
         # in non-chief workers which don't have logger dir
-        self.checkpoint_dir = os.path.normpath(checkpoint_dir) if checkpoint_dir is not None else checkpoint_dir
+        self.checkpoint_dir = checkpoint_dir
 
     def _setup_graph(self):
         assert self.checkpoint_dir is not None, \
@@ -121,7 +121,6 @@ class MinSaver(Callback):
         self.checkpoint_dir = checkpoint_dir
         if self.checkpoint_dir is None:
             self.checkpoint_dir = logger.get_logger_dir()
-        self.checkpoint_dir = os.path.normpath(self.checkpoint_dir)
 
     def _get_stat(self):
         try:

--- a/tensorpack/callbacks/saver.py
+++ b/tensorpack/callbacks/saver.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime
 
 from ..compat import tfv1 as tf
-from ..utils import logger
+from ..utils import fs, logger
 from .base import Callback
 
 __all__ = ['ModelSaver', 'MinSaver', 'MaxSaver']
@@ -45,7 +45,7 @@ class ModelSaver(Callback):
         # If None, allow it to be init, but fail later if used
         # For example, if chief_only=True, it can still be safely initialized
         # in non-chief workers which don't have logger dir
-        self.checkpoint_dir = checkpoint_dir
+        self.checkpoint_dir = fs.normpath(checkpoint_dir) if checkpoint_dir is not None else checkpoint_dir
 
     def _setup_graph(self):
         assert self.checkpoint_dir is not None, \
@@ -121,6 +121,7 @@ class MinSaver(Callback):
         self.checkpoint_dir = checkpoint_dir
         if self.checkpoint_dir is None:
             self.checkpoint_dir = logger.get_logger_dir()
+        self.checkpoint_dir = fs.normpath(self.checkpoint_dir)
 
     def _get_stat(self):
         try:

--- a/tensorpack/utils/fs.py
+++ b/tensorpack/utils/fs.py
@@ -10,7 +10,7 @@ from six.moves import urllib
 from . import logger
 from .utils import execute_only_once
 
-__all__ = ['mkdir_p', 'download', 'recursive_walk', 'get_dataset_path']
+__all__ = ['mkdir_p', 'download', 'recursive_walk', 'get_dataset_path', 'normpath']
 
 
 def mkdir_p(dirname):
@@ -104,6 +104,20 @@ def get_dataset_path(*args):
             logger.info("Created the directory {}.".format(d))
     assert os.path.isdir(d), d
     return os.path.join(d, *args)
+
+
+def normpath(path):
+    """
+    Normalizes a path to a folder by taking into consideration remote storages like Cloud storaged
+    referenced by '://' at the beginning of the path.
+
+    Args:
+        args: path to be normalized.
+
+    Returns:
+        str: normalized path.
+    """
+    return path if '://' in path else os.path.normpath(path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Removed normalizing the path where the TensorFlow checkpoints, model and TensorBoard event files are saved in order to be able to save these to remote storages in the Cloud, like Google Cloud Storage, which are references with paths like gs://BUCKET_NAME/path/to/folder.