### PR TITLE
Transpose conv bug

### DIFF
--- a/tensorpack/models/conv2d.py
+++ b/tensorpack/models/conv2d.py
@@ -209,36 +209,34 @@ def Conv2DTranspose(
         strides2d = shape2d(strides)
         kernel_shape = shape2d(kernel_size)
 
-        assert padding.lower() in ['valid', 'full', 'same'], "Padding {} is not supported!".format(padding)
+        assert padding.lower() in ['valid', 'same'], "Padding {} is not supported!".format(padding)
 
         if padding.lower() == 'valid':
-            shape_residue2d = [max(kernel_shape[0] - strides2d[0], 0),
-                               max(kernel_shape[1] - strides2d[1], 0)]
-        elif padding.lower() == 'full':
-            shape_residue2d = [2 - strides2d[0] - kernel_shape[0],
-                               2 - strides2d[1] - kernel_shape[1]]
+            shape_res2d = [max(kernel_shape[0] - strides2d[0], 0),
+                           max(kernel_shape[1] - strides2d[1], 0)]
         else:
-            shape_residue2d = shape2d(0)
+            shape_res2d = shape2d(0)
 
         if data_format == 'NCHW':
             channels_in = inputs.shape[1]
             out_shape_dyn = tf.stack(
                 [shape_dyn[0], filters,
-                 shape_dyn[2] * strides2d[0] + shape_residue2d[0],
-                 shape_dyn[3] * strides2d[1] + shape_residue2d[1]])
+                 shape_dyn[2] * strides2d[0] + shape_res2d[0],
+                 shape_dyn[3] * strides2d[1] + shape_res2d[1]])
             out_shape3_sta = [filters,
-                              None if inputs.shape[2] is None else inputs.shape[2] * strides2d[0] + shape_residue2d[0],
-                              None if inputs.shape[3] is None else inputs.shape[3] * strides2d[1] + shape_residue2d[1]]
+                              None if inputs.shape[2] is None else int(inputs.shape[2] * strides2d[0]) + shape_res2d[0],
+                              None if inputs.shape[3] is None else int(inputs.shape[3] * strides2d[1]) + shape_res2d[1]]
         else:
             channels_in = inputs.shape[-1]
             out_shape_dyn = tf.stack(
                 [shape_dyn[0],
-                 shape_dyn[1] * strides2d[0] + shape_residue2d[0],
-                 shape_dyn[2] * strides2d[1] + shape_residue2d[1],
+                 shape_dyn[1] * strides2d[0] + shape_res2d[0],
+                 shape_dyn[2] * strides2d[1] + shape_res2d[1],
                  filters])
-            out_shape3_sta = [None if inputs.shape[1] is None else inputs.shape[1] * strides2d[0] + shape_residue2d[0],
-                              None if inputs.shape[2] is None else inputs.shape[2] * strides2d[1] + shape_residue2d[1],
+            out_shape3_sta = [None if inputs.shape[1] is None else int(inputs.shape[1] * strides2d[0]) + shape_res2d[0],
+                              None if inputs.shape[2] is None else int(inputs.shape[2] * strides2d[1]) + shape_res2d[1],
                               filters]
+
 
         W = tf.get_variable('W', kernel_shape + [filters, channels_in], initializer=kernel_initializer)
         if use_bias:

--- a/tensorpack/models/conv2d.py
+++ b/tensorpack/models/conv2d.py
@@ -237,7 +237,6 @@ def Conv2DTranspose(
                               None if inputs.shape[2] is None else int(inputs.shape[2] * strides2d[1]) + shape_res2d[1],
                               filters]
 
-
         W = tf.get_variable('W', kernel_shape + [filters, channels_in], initializer=kernel_initializer)
         if use_bias:
             b = tf.get_variable('b', [filters], initializer=bias_initializer)

--- a/tensorpack/models/conv2d.py
+++ b/tensorpack/models/conv2d.py
@@ -207,28 +207,39 @@ def Conv2DTranspose(
         data_format = get_data_format(data_format, keras_mode=False)
         shape_dyn = tf.shape(inputs)
         strides2d = shape2d(strides)
-        channels_in = inputs.shape[1 if data_format == 'NCHW' else 3]
+        kernel_shape = shape2d(kernel_size)
+
+        assert padding.lower() in ['valid', 'full', 'same'], "Padding {} is not supported!".format(padding)
+
+        if padding.lower() == 'valid':
+            shape_residue2d = [max(kernel_shape[0] - strides2d[0], 0),
+                               max(kernel_shape[1] - strides2d[1], 0)]
+        elif padding.lower() == 'full':
+            shape_residue2d = [2 - strides2d[0] - kernel_shape[0],
+                               2 - strides2d[1] - kernel_shape[1]]
+        else:
+            shape_residue2d = shape2d(0)
+
         if data_format == 'NCHW':
             channels_in = inputs.shape[1]
             out_shape_dyn = tf.stack(
                 [shape_dyn[0], filters,
-                 shape_dyn[2] * strides2d[0],
-                 shape_dyn[3] * strides2d[1]])
+                 shape_dyn[2] * strides2d[0] + shape_residue2d[0],
+                 shape_dyn[3] * strides2d[1] + shape_residue2d[1]])
             out_shape3_sta = [filters,
-                              None if inputs.shape[2] is None else inputs.shape[2] * strides2d[0],
-                              None if inputs.shape[3] is None else inputs.shape[3] * strides2d[1]]
+                              None if inputs.shape[2] is None else inputs.shape[2] * strides2d[0] + shape_residue2d[0],
+                              None if inputs.shape[3] is None else inputs.shape[3] * strides2d[1] + shape_residue2d[1]]
         else:
             channels_in = inputs.shape[-1]
             out_shape_dyn = tf.stack(
                 [shape_dyn[0],
-                 shape_dyn[1] * strides2d[0],
-                 shape_dyn[2] * strides2d[1],
+                 shape_dyn[1] * strides2d[0] + shape_residue2d[0],
+                 shape_dyn[2] * strides2d[1] + shape_residue2d[1],
                  filters])
-            out_shape3_sta = [None if inputs.shape[1] is None else inputs.shape[1] * strides2d[0],
-                              None if inputs.shape[2] is None else inputs.shape[2] * strides2d[1],
+            out_shape3_sta = [None if inputs.shape[1] is None else inputs.shape[1] * strides2d[0] + shape_residue2d[0],
+                              None if inputs.shape[2] is None else inputs.shape[2] * strides2d[1] + shape_residue2d[1],
                               filters]
 
-        kernel_shape = shape2d(kernel_size)
         W = tf.get_variable('W', kernel_shape + [filters, channels_in], initializer=kernel_initializer)
         if use_bias:
             b = tf.get_variable('b', [filters], initializer=bias_initializer)

--- a/tensorpack/models/conv2d.py
+++ b/tensorpack/models/conv2d.py
@@ -206,6 +206,7 @@ def Conv2DTranspose(
             "Unsupported arguments due to Keras bug in TensorFlow 1.13"
         data_format = get_data_format(data_format, keras_mode=False)
         shape_dyn = tf.shape(inputs)
+        shape_sta = inputs.shape.as_list()
         strides2d = shape2d(strides)
         kernel_shape = shape2d(kernel_size)
 
@@ -218,23 +219,23 @@ def Conv2DTranspose(
             shape_res2d = shape2d(0)
 
         if data_format == 'NCHW':
-            channels_in = inputs.shape[1]
+            channels_in = shape_sta[1]
             out_shape_dyn = tf.stack(
                 [shape_dyn[0], filters,
                  shape_dyn[2] * strides2d[0] + shape_res2d[0],
                  shape_dyn[3] * strides2d[1] + shape_res2d[1]])
             out_shape3_sta = [filters,
-                              None if inputs.shape[2] is None else int(inputs.shape[2] * strides2d[0]) + shape_res2d[0],
-                              None if inputs.shape[3] is None else int(inputs.shape[3] * strides2d[1]) + shape_res2d[1]]
+                              None if shape_sta[2] is None else shape_sta[2] * strides2d[0] + shape_res2d[0],
+                              None if shape_sta[3] is None else shape_sta[3] * strides2d[1] + shape_res2d[1]]
         else:
-            channels_in = inputs.shape[-1]
+            channels_in = shape_sta[-1]
             out_shape_dyn = tf.stack(
                 [shape_dyn[0],
                  shape_dyn[1] * strides2d[0] + shape_res2d[0],
                  shape_dyn[2] * strides2d[1] + shape_res2d[1],
                  filters])
-            out_shape3_sta = [None if inputs.shape[1] is None else int(inputs.shape[1] * strides2d[0]) + shape_res2d[0],
-                              None if inputs.shape[2] is None else int(inputs.shape[2] * strides2d[1]) + shape_res2d[1],
+            out_shape3_sta = [None if shape_sta[1] is None else shape_sta[1] * strides2d[0] + shape_res2d[0],
+                              None if shape_sta[2] is None else shape_sta[2] * strides2d[1] + shape_res2d[1],
                               filters]
 
         W = tf.get_variable('W', kernel_shape + [filters, channels_in], initializer=kernel_initializer)

--- a/tensorpack/models/models_test.py
+++ b/tensorpack/models/models_test.py
@@ -75,16 +75,19 @@ class TestConv2DTranspose(TestModel):
 
     def test_shape_match(self):
         h, w = 12, 18
-        input = self.make_variable(np.random.rand(1, h, w, 3).astype("float32"))
-        for padding in ["same"]:
-            for stride in [1, 2]:
-                output = Conv2DTranspose(
-                    'deconv_s{}_pad{}'.format(stride, padding),
-                    input, 20, 3, strides=stride, padding=padding)
+        input_nhwc = self.make_variable(np.random.rand(1, h, w, 3).astype("float32"))
+        input_nchw = self.make_variable(np.random.rand(1, 3, h, w).astype("float32"))
 
-                static_shape = output.shape
-                dynamic_shape = self.run_variable(output).shape
-                self.assertTrue(static_shape == dynamic_shape)
+        for padding in ["same", "valid"]:
+            for stride in [1, 2]:
+                for data_format, input in zip(["NCHW", "NHWC"], [input_nchw, input_nhwc]):
+                    output = Conv2DTranspose(
+                        'deconv_s{}_pad{}_format{}'.format(stride, padding, data_format),
+                        input, 20, 3, strides=stride, padding=padding, data_format=data_format)
+
+                    static_shape = output.shape
+                    dynamic_shape = self.run_variable(output).shape
+                    self.assertTrue(static_shape == dynamic_shape)
 
 
 def run_test_case(case):

--- a/tensorpack/models/models_test.py
+++ b/tensorpack/models/models_test.py
@@ -76,7 +76,7 @@ class TestConv2DTranspose(TestModel):
     def test_shape_match(self):
         h, w = 12, 18
         input = self.make_variable(np.random.rand(1, h, w, 3).astype("float32"))
-        for padding in ["same"]:
+        for padding in ["same", "valid"]:
             for stride in [1, 2]:
                 output = Conv2DTranspose(
                     'deconv_s{}_pad{}'.format(stride, padding),

--- a/tensorpack/models/models_test.py
+++ b/tensorpack/models/models_test.py
@@ -75,19 +75,16 @@ class TestConv2DTranspose(TestModel):
 
     def test_shape_match(self):
         h, w = 12, 18
-        input_nhwc = self.make_variable(np.random.rand(1, h, w, 3).astype("float32"))
-        input_nchw = self.make_variable(np.random.rand(1, 3, h, w).astype("float32"))
-
-        for padding in ["same", "valid"]:
+        input = self.make_variable(np.random.rand(1, h, w, 3).astype("float32"))
+        for padding in ["same"]:
             for stride in [1, 2]:
-                for data_format, input in zip(["NCHW", "NHWC"], [input_nchw, input_nhwc]):
-                    output = Conv2DTranspose(
-                        'deconv_s{}_pad{}_format{}'.format(stride, padding, data_format),
-                        input, 20, 3, strides=stride, padding=padding, data_format=data_format)
+                output = Conv2DTranspose(
+                    'deconv_s{}_pad{}'.format(stride, padding),
+                    input, 20, 3, strides=stride, padding=padding)
 
-                    static_shape = output.shape
-                    dynamic_shape = self.run_variable(output).shape
-                    self.assertTrue(static_shape == dynamic_shape)
+                static_shape = output.shape
+                dynamic_shape = self.run_variable(output).shape
+                self.assertTrue(static_shape == dynamic_shape)
 
 
 def run_test_case(case):


### PR DESCRIPTION
Conv2DTranspose fails when either height or width shape is None since `tf.Dimension(None) is None ` doesn't evaluate to True. It seems that up until [#1323](https://github.com/tensorpack/tensorpack/pull/1323)  it was a silent bug, since arithmetic operations on tf.Dimension(None) are allowed