### PR TITLE
support writing events to cloud storage

### DIFF
--- a/tensorpack/callbacks/monitor.py
+++ b/tensorpack/callbacks/monitor.py
@@ -238,7 +238,6 @@ class TFEventWriter(MonitorBase):
         """
         if logdir is None:
             logdir = logger.get_logger_dir()
-        assert tf.gfile.IsDirectory(logdir), logdir
         self._logdir = fs.normpath(logdir)
         self._max_queue = max_queue
         self._flush_secs = flush_secs


### PR DESCRIPTION
tf.gfile.IsDirectory(logdir) won't work for cloud storage, for example gcs.

Thanks for your contribution!

Unless you want to send a simple several lines of PR that can be easily merged, please note the following:

* If you want to add a new feature,
  please open an issue first and indicate that you want to contribute.

  There are features that we prefer to not add to tensorpack, e.g. symbolic models
  (see details at https://tensorpack.readthedocs.io/tutorial/symbolic.html).
  Therefore it's good to have a discussion first.

* If you want to add a new example, please note that:

  1. We prefer to not have an example that is too similar to existing ones in terms of the tasks.

  2. Examples have to be able to reproduce (preferrably in some measurable metrics) published or well-known experiments and results.

* Please run `flake8 .` under the root of this repo to lint your code, and make sure the command produces no output.
