### PR TITLE
Fixed some deprecation warnings on Python 3

### DIFF
--- a/tensorpack/dataflow/common.py
+++ b/tensorpack/dataflow/common.py
@@ -5,7 +5,7 @@ from __future__ import division
 import itertools
 import numpy as np
 import pprint
-from collections import defaultdict, deque, Mapping
+from collections import defaultdict, deque
 from copy import copy
 import six
 import tqdm
@@ -16,6 +16,11 @@ from ..utils import logger
 from ..utils.utils import get_rng, get_tqdm, get_tqdm_kwargs
 from ..utils.develop import log_deprecated
 from .base import DataFlow, DataFlowReentrantGuard, ProxyDataFlow, RNGDataFlow
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 __all__ = ['TestDataSpeed', 'PrintData', 'BatchData', 'BatchDataByShape', 'FixedSizeData', 'MapData',
            'MapDataComponent', 'RepeatedData', 'RepeatedDataPoint', 'RandomChooseData',

--- a/tensorpack/tfutils/gradproc.py
+++ b/tensorpack/tfutils/gradproc.py
@@ -119,7 +119,10 @@ class MapGradient(GradientProcessor):
                 If it return None, the gradient is discarded (hence no update to the variable will happen).
             regex (str): used to match variables. Defaults to match all variables.
         """
-        args = inspect.getargspec(func).args
+        if six.PY2:
+            args = inspect.getargspec(func).args
+        else:
+            args = inspect.getfullargspec(func).args
         arg_num = len(args) - inspect.ismethod(func)
         assert arg_num in [1, 2], \
             "The function must take 1 or 2 arguments!  ({})".format(args)

--- a/tensorpack/utils/logger.py
+++ b/tensorpack/utils/logger.py
@@ -122,9 +122,9 @@ def set_logger_dir(dirname, action=None):
 
     if dir_nonempty(dirname):
         if not action:
-            _logger.warn("""\
+            _logger.warning("""\
 Log directory {} exists! Use 'd' to delete it. """.format(dirname))
-            _logger.warn("""\
+            _logger.warning("""\
 If you're resuming from a previous run, you can choose to keep it.
 Press any other key to exit. """)
         while not action:


### PR DESCRIPTION
Fixed some deprecations warning on Python 3:

* importing `Mapping` directly from `collections` has been deprecated since python 3.3. It should be imported from `collections.abc` instead. [[source]](https://docs.python.org/3.8/library/collections.html)
* `inspect.getargspec` has been deprecated since python 3.0, and should be replaced with `inspect.getfullargspec` [[source]](https://docs.python.org/3/library/inspect.html#inspect.getargspec)
* `logging.warn` has been deprecated since python 3.3, and should be replaced with `logging.warning` [[source]](https://docs.python.org/3/library/logging.html#logging.warning). Actually, `logging.warn` has never been documented, even in python 2, and is only an alias for `logging.warning` that was kept for backwards compatibility [[source]](https://stackoverflow.com/a/15655674/2679935)

I found a few other deprecations that I did not change, because I didn't find a simple compatible replacement:

* usage of `abc.abstractproperty` should be replaced with `abc.abstractmethod(property)` in python 3.3+
* the `imp` module has been deprecated since python 3.4, but I didn't find any trivial alternative to `imp.load_source`