### PR TITLE
fix input dtype not matching variable dtype

### DIFF
--- a/tensorpack/models/conv2d.py
+++ b/tensorpack/models/conv2d.py
@@ -241,7 +241,7 @@ def Conv2DTranspose(
                               filters]
 
         inputs_dtype = inputs.dtype
-        W = tf.get_variable('W', kernel_shape + [filters, channels_in], 
+        W = tf.get_variable('W', kernel_shape + [filters, channels_in],
                             dtype=inputs_dtype, initializer=kernel_initializer)
         if use_bias:
             b = tf.get_variable('b', [filters], dtype=inputs_dtype, initializer=bias_initializer)

--- a/tensorpack/models/conv2d.py
+++ b/tensorpack/models/conv2d.py
@@ -241,7 +241,8 @@ def Conv2DTranspose(
                               filters]
 
         inputs_dtype = inputs.dtype
-        W = tf.get_variable('W', kernel_shape + [filters, channels_in], dtype=inputs_dtype, initializer=kernel_initializer)
+        W = tf.get_variable('W', kernel_shape + [filters, channels_in], 
+                            dtype=inputs_dtype, initializer=kernel_initializer)
         if use_bias:
             b = tf.get_variable('b', [filters], dtype=inputs_dtype, initializer=bias_initializer)
         conv = tf.nn.conv2d_transpose(

--- a/tensorpack/models/conv2d.py
+++ b/tensorpack/models/conv2d.py
@@ -240,9 +240,10 @@ def Conv2DTranspose(
                               None if shape_sta[2] is None else shape_sta[2] * strides2d[1] + shape_res2d[1],
                               filters]
 
-        W = tf.get_variable('W', kernel_shape + [filters, channels_in], initializer=kernel_initializer)
+        input_dtype = inputs.dtype
+        W = tf.get_variable('W', kernel_shape + [filters, channels_in], dtype=inputs_dtype, initializer=kernel_initializer)
         if use_bias:
-            b = tf.get_variable('b', [filters], initializer=bias_initializer)
+            b = tf.get_variable('b', [filters], dtype=inputs_dtype, initializer=bias_initializer)
         conv = tf.nn.conv2d_transpose(
             inputs, W, out_shape_dyn,
             shape4d(strides, data_format=data_format),

--- a/tensorpack/models/conv2d.py
+++ b/tensorpack/models/conv2d.py
@@ -105,9 +105,9 @@ def Conv2D(
             kwargs['dilations'] = shape4d(dilation_rate, data_format=data_format)
 
         # matching input dtype (ex. tf.float16) since the default dtype of variable if tf.float32
-        input_dtype = inputs.dtype
+        inputs_dtype = inputs.dtype
         W = tf.get_variable(
-            'W', filter_shape, dtype=input_dtype, initializer=kernel_initializer)
+            'W', filter_shape, dtype=inputs_dtype, initializer=kernel_initializer)
 
         if use_bias:
             b = tf.get_variable('b', [out_channel], dtype=inputs_dtype, initializer=bias_initializer)
@@ -240,7 +240,7 @@ def Conv2DTranspose(
                               None if shape_sta[2] is None else shape_sta[2] * strides2d[1] + shape_res2d[1],
                               filters]
 
-        input_dtype = inputs.dtype
+        inputs_dtype = inputs.dtype
         W = tf.get_variable('W', kernel_shape + [filters, channels_in], dtype=inputs_dtype, initializer=kernel_initializer)
         if use_bias:
             b = tf.get_variable('b', [filters], dtype=inputs_dtype, initializer=bias_initializer)

--- a/tensorpack/models/conv2d.py
+++ b/tensorpack/models/conv2d.py
@@ -104,11 +104,13 @@ def Conv2D(
         if get_tf_version_tuple() >= (1, 5):
             kwargs['dilations'] = shape4d(dilation_rate, data_format=data_format)
 
+        # matching input dtype (ex. tf.float16) since the default dtype of variable if tf.float32
+        input_dtype = inputs.dtype
         W = tf.get_variable(
-            'W', filter_shape, initializer=kernel_initializer)
+            'W', filter_shape, dtype=input_dtype, initializer=kernel_initializer)
 
         if use_bias:
-            b = tf.get_variable('b', [out_channel], initializer=bias_initializer)
+            b = tf.get_variable('b', [out_channel], dtype=inputs_dtype, initializer=bias_initializer)
 
         if split == 1:
             conv = tf.nn.conv2d(inputs, W, stride, padding.upper(), **kwargs)


### PR DESCRIPTION
By default, all tensorflow variable has the dtype `tf.float32`. So, if the input has dtype `tf.float16`, then in the branch I edited, there is a dtype miss-matching between the input and the variable.

It will cause the error

> TypeError: Input 'filter' of 'Conv2D' Op has type float32 that does not match type float16 of argument 'input'.

The bug is discovered by running the code under repo [https://github.com/facebookresearch/ImageNet-Adversarial-Training](ImageNet-Adversarial-Training) with the following command

```bash
python3 main.py --data [imagenet training data dir] \
        --use-fp16xla --batch 256 --attack-iter 30 --attack-epsilon 16.0 --arch ResNeXtDenoiseAll -d 50
```