### PR TITLE
Fix Faster-RCNN d2_convert error.

### DIFF
--- a/examples/FasterRCNN/convert_d2/convert_d2.py
+++ b/examples/FasterRCNN/convert_d2/convert_d2.py
@@ -109,10 +109,11 @@ def convert_weights(d, cfg):
         _convert_box_predictor("roi_heads.box_predictor", "fastrcnn/outputs" if has_fpn else "fastrcnn")
 
     # mask head
-    for fcn in range(cfg.MODEL.ROI_MASK_HEAD.NUM_CONV):
-        _convert_conv(f"roi_heads.mask_head.mask_fcn{fcn+1}", f"maskrcnn/fcn{fcn}")
-    _convert_conv("roi_heads.mask_head.deconv", "maskrcnn/deconv")
-    _convert_conv("roi_heads.mask_head.predictor", "maskrcnn/conv")
+    if cfg.MODEL.MASK_ON:
+        for fcn in range(cfg.MODEL.ROI_MASK_HEAD.NUM_CONV):
+            _convert_conv(f"roi_heads.mask_head.mask_fcn{fcn+1}", f"maskrcnn/fcn{fcn}")
+        _convert_conv("roi_heads.mask_head.deconv", "maskrcnn/deconv")
+        _convert_conv("roi_heads.mask_head.predictor", "maskrcnn/conv")
 
     for k in list(d.keys()):
         if "cell_anchors" in k:


### PR DESCRIPTION
Convert Faster-RCNN with following command:
`python convert_d2.py --d2-config detectron2/configs/COCO-Detection/faster_rcnn_R_50_FPN_1x.yaml --d2-pkl model_final_b275ba.pkl --output R50FPN-d2-converted.npz`
Raise an error:
`  File "convert_d2.py", line 141, in <module>
    tp_dict = convert_weights(d2_dict, cfg)
  File "convert_d2.py", line 114, in convert_weights
    _convert_conv(f"roi_heads.mask_head.mask_fcn{fcn+1}", f"maskrcnn/fcn{fcn}")
  File "convert_d2.py", line 39, in _convert_conv
    src_w = d.pop(src + ".weight").transpose(2, 3, 1, 0)
KeyError: 'roi_heads.mask_head.mask_fcn1.weight'`

This happens as the code tolerates mask_on. Add a flag to fix this.