### PR TITLE
Improve compatibility to tensorflow 2.3

### DIFF
--- a/tensorpack/train/config.py
+++ b/tensorpack/train/config.py
@@ -2,8 +2,8 @@
 # File: config.py
 
 import os
-import tensorflow as tf
 
+from ..compat import tfv1
 from ..callbacks import (
     JSONWriter, MergeAllSummaries, MovingAverageSummary, ProgressBar, RunUpdateOps, ScalarPrinter, TFEventWriter)
 from ..dataflow.base import DataFlow
@@ -237,6 +237,6 @@ class AutoResumeTrainConfig(TrainConfig):
         if not dir:
             return None
         path = os.path.join(dir, 'checkpoint')
-        if not tf.gfile.Exists(path):
+        if not tfv1.gfile.Exists(path):
             return None
         return SaverRestore(path)


### PR DESCRIPTION
When trying to run my tensorpack code (which I developed with tensorflow 1) with tensorflow 2.3, I got two errors inside tensorpack. I fixed both errors in these commits. Now my tensorpack code runs fine with tensorflow 2.3.

Best,
Philipp

PS: Thanks for developing tensorpack! It is a great library!