### PR TITLE
TensorFlow Version 1 Compatibility Fix

### DIFF
--- a/examples/FasterRCNN/eval.py
+++ b/examples/FasterRCNN/eval.py
@@ -6,7 +6,6 @@ import json
 import numpy as np
 import os
 import sys
-import tensorflow as tf
 from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack

--- a/examples/FasterRCNN/eval.py
+++ b/examples/FasterRCNN/eval.py
@@ -23,6 +23,7 @@ from common import CustomResize, clip_boxes
 from config import config as cfg
 from data import get_eval_dataflow
 from dataset import DatasetRegistry
+from tensorpack.compat import tfv1
 
 try:
     import horovod.tensorflow as hvd
@@ -243,7 +244,7 @@ class EvalCallback(Callback):
                 self.dataflow = get_eval_dataflow(self._eval_dataset,
                                                   shard=hvd.local_rank(), num_shards=hvd.local_size())
 
-            self.barrier = hvd.allreduce(tf.random_normal(shape=[1]))
+            self.barrier = hvd.allreduce(tfv1.random_normal(shape=[1]))
 
     def _build_predictor(self, idx):
         return self.trainer.get_predictor(self._in_names, self._out_names, device=idx)

--- a/tensorpack/train/trainers.py
+++ b/tensorpack/train/trainers.py
@@ -5,6 +5,7 @@ import multiprocessing as mp
 import os
 import sys
 import tensorflow as tf
+from tensorpack.compat import tfv1
 
 from ..callbacks import CallbackFactory, RunOp
 from ..graph_builder.distributed import DistributedParameterServerBuilder, DistributedReplicatedBuilder
@@ -487,7 +488,7 @@ class HorovodTrainer(SingleCostTrainer):
         # broadcast_op should be the last setup_graph: it needs to be created
         # "right before" the graph is finalized,
         # because it needs to capture all the variables (which may be created by callbacks).
-        self._num_global_variables = len(tf.global_variables())
+        self._num_global_variables = len(tfv1 .global_variables())
         self._broadcast_op = self.hvd.broadcast_global_variables(0)
 
         # it's important that our NewSessionCreator does not finalize the graph


### PR DESCRIPTION
Added TensorFlow V1 compatibility fix to ```tensorpack/train/trainers.py``` and ```examples/FasterRCNN/eval.py``` so FasterRCNN model can be trained with latest version of TensorFlow 2.